### PR TITLE
Patch to address opening/closing of test contexts

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,7 +1,7 @@
 export(auto_test)
 export(auto_test_package)
 export(colourise)
-export(context)
+export(start_context, end_context, next_context, context)
 export(expect_that)
 import(stringr)
 S3method(print, expectation)

--- a/R/context.r
+++ b/R/context.r
@@ -5,12 +5,20 @@
 #' in a single file if you so choose.
 #'
 #' @param desc description of context.  Should start with a capital letter.
-#' @export
+#' @export start_context end_context next_context context
+#' @aliases next_context context
 #' @examples
-#' context("String processing")
-#' context("Remote procedure calls")
-context <- function(desc) {
-  test_reporter()$end_context()
+#' start_context("String processing")
+#' next_context("Remote procedure calls")
+#' end_context()
+start_context <- function(desc) {
   test_reporter()$start_context(desc)
 }
-
+end_context <- function() {
+  test_reporter()$end_context()
+}
+next_context <- function(desc) {
+  end_context()
+  start_context(desc)
+}
+context <- next_context


### PR DESCRIPTION
I was working on a new test reporter and I noticed that calling `context()` tries to close the previous context and then open a new one.  My reporter prints (#pass/#failed) at the end of each testing context and so this behavior was giving me two problems:
- The first call to `context()` in a test file tries to close a context before there has been a chance for one to be opened.
- The last context opened in the test file never gets closed and so my reporter is not able to summarize it.

This patch adds three new functions `start_context(desc)`, `end_context()` and `next_context(desc)`.  `context()` is now set to be an alias of `next_context()` so that existing unit test scripts will not be broken.
