### PR TITLE
Added `info` and `label` parameters to expect_* short form functions.

### DIFF
--- a/R/expectations.r
+++ b/R/expectations.r
@@ -140,12 +140,16 @@ equals <- function(expected, label = NULL, ...) {
     )
   }
 }
-expect_equal <- function(actual, expected, info = NULL, label = NULL) {
+expect_equal <- function(actual, expected, info = NULL, label = NULL,
+                         expected.label = NULL) {
   if (is.null(label)) {
     label <- find_expr("actual")
   }
-  expect_that(actual, info = info, label = find_expr("actual"),
-    equals(expected, label = find_expr("expected")))
+  if (is.null(expected.label)) {
+    expected.label <- find_expr("expected")
+  }
+  expect_that(actual, info = info, label = label,
+    equals(expected, label = expected.label))
 }
 
 
@@ -174,12 +178,16 @@ is_equivalent_to <- function(expected, label = NULL) {
     equals(expected, check.attributes = FALSE)(actual)
   } 
 }
-expect_equivalent <- function(actual, expected, info = NULL, label = NULL) {
+expect_equivalent <- function(actual, expected, info = NULL, label = NULL,
+                              expected.label=NULL) {
   if (is.null(label)) {
     label <- find_expr("actual")
   }
+  if (is.null(expected.label)) {
+    expected.label <- find_expr("expected")
+  }
   expect_that(actual, info = info, label = label,
-    is_equivalent_to(expected, label = find_expr("expected")))
+    is_equivalent_to(expected, label = expected.label))
 }
 
 #' Expectation: is the object identical to another?
@@ -223,12 +231,16 @@ is_identical_to <- function(expected, label = NULL) {
     )
   }
 }
-expect_identical <- function(actual, expected, info = NULL, label = NULL) {
+expect_identical <- function(actual, expected, info = NULL, label = NULL,
+                             expected.label = NULL) {
   if (is.null(label)) {
     label <- find_expr("actual")
   }
-  expect_that(actual, info = info, label = find_expr("actual"),
-    is_identical_to(expected, label = find_expr("expected")))
+  if (is.null(expected.label)) {
+    expected.label <- find_expr("expected")
+  }
+  expect_that(actual, info = info, label = label,
+    is_identical_to(expected, label = expected.label))
 }
 
 #' Expectation: does string match regular expression?
@@ -256,11 +268,12 @@ matches <- function(regexp, all = TRUE) {
     )
   }  
 }
-expect_match <- function(actual, expected, info = NULL, label = NULL) {
+expect_match <- function(actual, expected, info = NULL, label = NULL,
+                         all = TRUE) {
   if (is.null(label)) {
     label <- find_expr("actual")
   }
-  expect_that(actual, matches(expected), info = info, label = label)
+  expect_that(actual, matches(expected, all = all), info = info, label = label)
 }
 
 #' Expectation: does printed output match a regular expression?
@@ -341,7 +354,8 @@ gives_warning <- function(regexp = NULL) {
     }
   }
 } 
-expect_warning <- function(actual, expected = NULL) {
+expect_warning <- function(actual, expected = NULL, info = NULL,
+                           label = NULL) {
   if (is.null(label)) {
     label <- find_expr("actual")
   }


### PR DESCRIPTION
I'm not sure if I missed something -- seemed too easy, but I added `info` and `label` parameters as requested/discussed in Issue #11.

The parameters in all the short form functions keep the same ordering as the params from the expect_that function: `actual`, `expected`, `info`, `label`

I added extra paremeters to any short form to match its "long form" expectation, eg. I added an `all` parameter after the aforementioned four parameters in the `expect_match` match function which passes down to the inner `matches` call.

Lastly, I wasn't sure how to handle the "expected labels" in `expect_identical|equivalent|equal`, so I added an `expected.label` parameter to (maybe you'd prefer `expected_label`).

Anyway, I think that pretty much sums it up.
