### PR TITLE
Update required R version to 2.12.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Description: A testing package specifically tailored for R
     that's fun, flexible and easy to set up.
 URL: http://had.co.nz/
 Depends:
-    R (>= 2.8)
+    R (>= 2.12.0)
 Imports:
     digest,
     stringr (>= 0.4),


### PR DESCRIPTION
`test_that` version 0.6 moved to using reference classes. These objects require R 2.12.0 or newer.

Here are the results of running the `test_that` testsuite in R 2.12.0 on OS X using `stringr` 0.5 and `evaluate` 0.3 (the newest versions of these packages require R 2.14.x or newer).

```
R version 2.12.0 (2010-10-15)
Copyright (C) 2010 The R Foundation for Statistical Computing
ISBN 3-900051-07-0
Platform: x86_64-apple-darwin10.8.0 (64-bit)

...

> install.packages('testthat', type = 'source')
trying URL 'http://cran.cnr.Berkeley.edu/src/contrib/testthat_0.6.tar.gz'
Content type 'application/x-gzip' length 24174 bytes (23 Kb)
opened URL
==================================================
downloaded 23 Kb

* installing *source* package ‘testthat’ ...
** R
** inst
** preparing package for lazy loading
** help
*** installing help indices
** building package indices ...
** testing if installed package can be loaded

* DONE (testthat)

The downloaded packages are in
    ‘/private/var/folders/Iy/IyVZ0c2iFn042dabCYLImE+++TI/-Tmp-/RtmpUcA2rF/downloaded_packages’
Updating HTML index of packages in '.Library'

> require(testthat)
Loading required package: testthat
> test_package('testthat')
Bare expectations should work : ..
Basic tests : .....
Contexts : ....
Expectations : ...............
Reporter : ...
Watcher components : ..................
Should fail : 12345


1. Failure: false is not true (should fail) ------------------------------------
FALSE isn't true

2. Failure: true is not false (should fail) ------------------------------------
TRUE isn't false

3. Error: random errors are caught (should err) --------------------------------
could not find function "function_that_doesnt_exist"

4. Error: errors are captured (should err) -------------------------------------
I made a mistake
1: f()
2: g()
3: stop("I made a mistake", call. = FALSE)

5. Failure:  -------------------------------------------------------------------
1 not equal to 2
Mean relative difference: 0.5
Error: Test failures
In addition: Warning message:
In getPackageName(where) :
  Created a package name, "2012-01-26 13:50:31", when none found
```
