### PR TITLE
Fix small spelling error in example

### DIFF
--- a/R/test-that.r
+++ b/R/test-that.r
@@ -16,7 +16,7 @@
 #' @importFrom evaluate try_capture_stack create_traceback is.error
 #' @export
 #' @examples
-#' test_that("trigonometric functions match identies", {
+#' test_that("trigonometric functions match identities", {
 #'   expect_that(sin(pi / 4), equals(1 / sqrt(2)))
 #'   expect_that(cos(pi / 4), equals(1 / sqrt(2)))
 #'   expect_that(tan(pi / 4), equals(1))


### PR DESCRIPTION
Fix "identies" to "identities"
