### PR TITLE
Suppress stray output from tests

### DIFF
--- a/R/test-files.r
+++ b/R/test-files.r
@@ -29,7 +29,7 @@ test_dir <- function(path, filter = NULL, reporter = "summary", env = NULL) {
     files <- files[str_detect(test_names, filter)]
   }
   with_reporter(reporter, lapply(files, function(file) {
-    sys.source(file, chdir = TRUE, envir = new.env(parent = env))
+    capture.output(sys.source(file, chdir = TRUE, envir = new.env(parent = env)))
     end_context()
   }))
 }


### PR DESCRIPTION
When outputting TAP results, some of our tests have output (because the code itself has output).  Rather than suppressing output in each test, I am suggesting suppressing output while running the tests.  I don't know if this is the best place to do so, but this change allows me to continue to use my TAP setup with jenkins.
