### PR TITLE
Fix minor typo in check_package documentation

### DIFF
--- a/R/test-package.r
+++ b/R/test-package.r
@@ -2,7 +2,7 @@
 #'
 #' Test are run in an environment that inherits from the package environment
 #' so that tests can access non-exported functions and variables. Tests should
-#' be placed in either \code{inst/tests}, or (better) \code{tests/testhat}.
+#' be placed in either \code{inst/tests}, or (better) \code{tests/testthat}.
 #'
 #' @section R CMD check:
 #' Use \code{test_package} to test an installed package, or in


### PR DESCRIPTION
Documentation on line 5 in `testthat/R/test-package.r` has 

> either \code{inst/tests}, or (better) \code{tests/testhat}.

Latter directory name should probably be `\code{tests/testthat}`.
