### PR TITLE
Better handling of NAs in `compare_state`.

### DIFF
--- a/R/reporter-silent.r
+++ b/R/reporter-silent.r
@@ -29,7 +29,7 @@ SilentReporter <- setRefClass("SilentReporter", contains = "Reporter",
 
     add_result = function(result) {
       if (result$passed) return()
-      failures[[test]] <<- new_failure
+      failures[[test]] <<- result
     }
   )
 )

--- a/R/watcher.r
+++ b/R/watcher.r
@@ -73,6 +73,18 @@ dir_state <- function(path, pattern = NULL, hash = TRUE) {
   }
 }
 
+#' Compare two logical values, treating all NAs as equal.
+#'
+#' @param x logical
+#' @param y logical
+#' @return \code{TRUE} iff the values are equal or both \code{NA}
+#' @keywords internal
+equal_or_NAs <- function(x, y) {
+  same <- (is.na(x) & is.na(y)) | (x == y)
+  same[is.na(same)] <- FALSE
+  same
+}
+
 #' Compare two directory states.
 #'
 #' @param old previous state
@@ -85,7 +97,7 @@ compare_state <- function(old, new) {
   deleted <- setdiff(names(old), names(new))
 
   same <- intersect(names(old), names(new))
-  modified <- names(new[same])[new[same] != old[same]]
+  modified <- names(new[same])[!equal_or_NAs(old[same], new[same])]
 
   n <- length(added) + length(deleted) + length(modified)
 

--- a/inst/tests/test-watcher.r
+++ b/inst/tests/test-watcher.r
@@ -35,6 +35,31 @@ if (interactive()) {
     expect_that(basename(diff$modified), equals("file3"))
    })
 
+  test_that("compare_state handles NA correctly", {
+    empty <- character(0)
+    one_NA <- c(one = NA)
+    one <- c(one = "value")
+
+    diff <- compare_state(one, one_NA)
+    expect_that(diff$n, equals(1))
+    expect_that(diff$modified, equals("one"))
+
+    diff <- compare_state(one, empty)
+    expect_that(diff$n, equals(1))
+    expect_that(diff$deleted, equals("one"))
+
+    diff <- compare_state(empty, one)
+    expect_that(diff$n, equals(1))
+    expect_that(diff$added, equals("one"))
+
+    diff <- compare_state(one_NA, empty)
+    expect_that(diff$n, equals(1))
+    expect_that(diff$deleted, equals("one"))
+
+    diff <- compare_state(empty, one_NA)
+    expect_that(diff$n, equals(1))
+    expect_that(diff$added, equals("one"))
+  })
 
   test_that("watcher works correctly", {
       loc <- tempfile("watcher", tmpdir = "/tmp")


### PR DESCRIPTION
This fixes an issue pointed out by Karl Millar, where NAs in `dir_state`
results would cause misreporting of results in `compare_state`. (I also fixed
a random missing symbol while I was here.)

This hasn't fixed everything, in the sense that there are still some races
left in tests. I don't know how far we can really push it.
