### PR TITLE
removed the warning in case the srcref of the expect_call can not be fou...

### DIFF
--- a/R/expect-that.r
+++ b/R/expect-that.r
@@ -73,7 +73,6 @@ find_test_srcref <- function() {
   nbe <- Find(.is_test_frame, seq_len(sys.nframe()), right = TRUE)
   
   if (length(nbe) == 0 || is.na(nbe)) {
-    warning("Could not find any call to an expect_ function")
     return(NULL)
   }
   


### PR DESCRIPTION
...nd, e.g. for a bare expectation, as reported by Hadley
