### PR TITLE
Explicitly test if 'testthat' is a directory.

### DIFF
--- a/R/test-package.r
+++ b/R/test-package.r
@@ -50,8 +50,8 @@ test_package <- function(package, filter = NULL, reporter = "summary") {
 test_check <- function(package, filter = NULL, reporter = "summary") {
   require(package, character.only = TRUE)
 
-  test_path <- "testthat/"
-  if (!file.exists(test_path)) {
+  test_path <- "testthat"
+  if (!file_test('-d', test_path)) {
     stop("No tests found for ", package, call. = FALSE)
   }
 


### PR DESCRIPTION
Using the latest testhat and devtools from github, on R 3.0.2 on Windows 7 I get the error message "No tests found" using test_check() on Windows (and also when test_check() is called from check() in the devtools package).

This appears to be because `!file.exists("testthat/")` (with a trailing slash) evaluates as `TRUE` on Windows even when the `testthat` folder exists. `!file.exists("testthat")` evaluates as `FALSE` on Windows if the `testthat` folder exists (though of course it doesn't test if `testthat` is a folder or not. This patch fixes the problem by explicitly testing if `testthat` is a folder.
