### PR TITLE
enable debugging in rstudio when testing a file

### DIFF
--- a/R/test-files.r
+++ b/R/test-files.r
@@ -95,6 +95,9 @@ test_file <- function(path, reporter = "summary",
   old <- setwd(dirname(path))
   on.exit(setwd(old))
   
+  # set debug mode if we are using RStudio
+  if(!is.na(Sys.getenv("RSTUDIO",unset=NA)))
+    try(debugSource(basename(path)),silent=TRUE)
   sys.source2(basename(path), new.env(parent = parent_env))
   end_context()
 }


### PR DESCRIPTION
- not sure if the try is necessary 
  (I was thinking about older Rstudio versions - don't know how to test version)
- this works for me for breakpoints in functions
  but not for top level breakpoints in tests themselves
