### PR TITLE
fix path to recommended tests directory

### DIFF
--- a/R/test-package.r
+++ b/R/test-package.r
@@ -67,7 +67,7 @@ test_package <- function(package, filter = NULL, reporter = "summary") {
 test_check <- function(package, filter = NULL, reporter = "summary") {
   require(package, character.only = TRUE)
 
-  test_path <- "testthat"
+  test_path <- "tests/testthat"
   if (!file_test('-d', test_path)) {
     stop("No tests found for ", package, call. = FALSE)
   }


### PR DESCRIPTION
Hi,
I've been unsuccesfully trying to use 'test_check' as recommended from 0.8 but kept saying "No tests found for ..." (at path "testthat").
This fixed for me ... but find it strange since I shouldn't be the only one with the problem (am I missing anything?).
Regards and thanks.
Javier
