### PR TITLE
Remove deprecated function from examples

### DIFF
--- a/R/test-that.R
+++ b/R/test-that.R
@@ -205,5 +205,5 @@ test_code <- function(test, code, env = test_env(), skip_on_empty = TRUE) {
 #' library(testthat)
 #' a <- 9
 #' expect_that(a, is_less_than(10))
-#' expect_less_than(a, 10)
+#' expect_lt(a, 10)
 NULL


### PR DESCRIPTION
Updated `expect_less_than` as per [NEWS update from v1.0.0](../blob/70c4d53813d4191b370849412846c97daef3d867/NEWS.md#new-expectations)

Is it also necessary to keep the file [test-not.R](../blob/70c4d53813d4191b370849412846c97daef3d867/tests/testthat/test-not.R) if `not()` is deprecated as well?