### PR TITLE
Handle case when `env_test$package` is `NULL`

### DIFF
--- a/R/test-example.R
+++ b/R/test-example.R
@@ -29,6 +29,10 @@ test_examples_source <- function(path = "../..") {
 }
 
 test_examples_installed <- function(package = env_test$package) {
+  if (is.null(package)) {
+    return()
+  }
+
   Rd <- tools::Rd_db(package = package)
   if (length(Rd) == 0) {
     return()


### PR DESCRIPTION
This changes the kimisc error to

```
> test_check("kimisc")
     Loading required package: kimisc
     testthat results ================================================================
     OK: 54 SKIPPED: 15 FAILED: 0
     > test_examples()
     Error: Could not find examples
     Execution halted
```

If I remove the call to `test_examples()` from `R/tests-all.R` (https://github.com/krlmlr/kimisc/blob/master/tests/test-all.R#L4), retaining the one in (https://github.com/krlmlr/kimisc/blob/master/tests/testthat/test-kimisc.R#L3) the tests pass without error.