### PR TITLE
Use cyan for times instead of white

### DIFF
--- a/R/reporter-progress.R
+++ b/R/reporter-progress.R
@@ -111,7 +111,7 @@ ProgressReporter <- R6::R6Class("ProgressReporter", inherit = Reporter,
       self$show_status(complete = TRUE)
 
       if (time[[3]] > self$min_time) {
-        self$cat(crayon::white(sprintf(" [%.1f s]", time[[3]])))
+        self$cat(crayon::cyan(sprintf(" [%.1f s]", time[[3]])))
       }
       self$cat_line()
 


### PR DESCRIPTION
white is really hard to see on light themes. Here is how it looks on all the light themes used in RStudio.

![light](https://user-images.githubusercontent.com/205275/31689284-ef922852-b35c-11e7-800a-2ffa6c03fb40.png)

However cyan is much easier to see on light themes.

![light-new](https://user-images.githubusercontent.com/205275/31689306-0449e546-b35d-11e7-932e-4cbb5b02a539.png)

But still looks good on dark themes as well

![dark-new](https://user-images.githubusercontent.com/205275/31689323-0d2fedf4-b35d-11e7-8eb7-b60d214bbf0b.png)


