### PR TITLE
Don't promote retirement cycle on CRAN

### DIFF
--- a/R/test-directory.R
+++ b/R/test-directory.R
@@ -75,7 +75,11 @@ test_dir <- function(path,
   on.exit(source_test_teardown(path, env), add = TRUE)
 
   withr::local_envvar(list(R_TESTS = "", TESTTHAT = "true"))
-  withr::local_options(list(oldie_verbose_retirement = TRUE))
+
+  # Promote retirement stages except on CRAN
+  if (identical(Sys.getenv("NOT_CRAN"), "true")) {
+    withr::local_options(list(lifecycle_verbose_retirement = TRUE))
+  }
 
   paths <- find_test_scripts(path, filter, ...)
 


### PR DESCRIPTION
And use `lifecycle_` prefix instead of `oldie_` in prevision of new package name.

Closes #662