### PR TITLE
Need rlang dev version for is_reference()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,9 @@ Suggests:
     xml2
 VignetteBuilder: knitr
 Encoding: UTF-8
-Remotes: r-lib/cli
+Remotes: 
+    r-lib/cli,
+    r-lib/rlang
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.0.1
 Collate: 


### PR DESCRIPTION
The CRAN version doesn't seem to have it yet. This is just a reminder to release rlang beforehand.

Travis build: https://travis-ci.org/r-lib/testthat/jobs/300622851#L1309