### PR TITLE
Fix encoding issues in output recording and comparison

### DIFF
--- a/R/capture-output.R
+++ b/R/capture-output.R
@@ -51,6 +51,6 @@ eval_with_output <- function(code, print = FALSE, width = 80) {
   list(
     val = result$value,
     vis = result$visible,
-    out = read_lines(temp)
+    out = read_lines(temp, encoding = "unknown")
   )
 }

--- a/R/expect-known.R
+++ b/R/expect-known.R
@@ -57,6 +57,12 @@ expect_known_output <- function(object, file,
     ref_out <- read_lines(file)
     if (update) {
       write_lines(act$out, file)
+      if (!all_utf8(act$out)) {
+        warning("New reference output is not UTF-8 encoded", call. = FALSE)
+      }
+    }
+    if (!all_utf8(ref_out)) {
+      warning("Reference output is not UTF-8 encoded", call. = FALSE)
     }
 
     comp <- compare(act$out, enc2native(ref_out), ...)

--- a/R/expect-known.R
+++ b/R/expect-known.R
@@ -59,7 +59,7 @@ expect_known_output <- function(object, file,
       write_lines(act$out, file)
     }
 
-    comp <- compare(act$out, ref_out, ...)
+    comp <- compare(act$out, enc2native(ref_out), ...)
     expect(
       comp$equal,
       sprintf(

--- a/R/expect-output.R
+++ b/R/expect-output.R
@@ -102,7 +102,7 @@ expect_output <- function(object, regexp = NULL, ..., info = NULL, label = NULL)
       info = info
     )
   } else {
-    expect_match(act$cap, regexp, ..., info = info, label = act$lab)
+    expect_match(act$cap, enc2native(regexp), ..., info = info, label = act$lab)
   }
 
   invisible(act$val)

--- a/R/utils-io.R
+++ b/R/utils-io.R
@@ -1,8 +1,8 @@
 readLines <- function(...) stop("Use read_lines!")
 writeLines <- function(...) stop("Use write_lines!")
 
-read_lines <- function(path, n = -1L) {
-  base::readLines(path, n = n, encoding = "UTF-8", warn = FALSE)
+read_lines <- function(path, n = -1L, encoding = "UTF-8") {
+  base::readLines(path, n = n, encoding = encoding, warn = FALSE)
 }
 
 write_lines <- function(text, path) {

--- a/R/utils-io.R
+++ b/R/utils-io.R
@@ -8,3 +8,7 @@ read_lines <- function(path, n = -1L, encoding = "UTF-8") {
 write_lines <- function(text, path) {
   base::writeLines(enc2utf8(text), path, useBytes = TRUE)
 }
+
+all_utf8 <- function(x) {
+  ! any(is.na(iconv(x, "UTF-8", "UTF-8")))
+}

--- a/tests/testthat/test-expect-known-output.R
+++ b/tests/testthat/test-expect-known-output.R
@@ -38,3 +38,16 @@ test_that("updates by default", {
   expect_failure(expect_known_output(cat("oops"), file, update = TRUE))
   expect_success(expect_known_output(cat("oops"), file))
 })
+
+test_that("Warning for non-UTF-8 reference files", {
+  x <- "\xe9\xe1\xed\xf6\xfc"
+  Encoding(x) <- "latin1"
+
+  tmp <- tempfile()
+  on.exit(unlink(tmp), add = TRUE)
+  writeBin(x, tmp)
+
+  expect_failure(
+    expect_warning(expect_known_output("foobar", tmp, update = FALSE))
+  )
+})

--- a/tests/testthat/test-expect-output.R
+++ b/tests/testthat/test-expect-output.R
@@ -30,3 +30,8 @@ test_that("... passed on to grepl", {
 test_that("returns first argument", {
   expect_equal(expect_output(1, NA), 1)
 })
+
+test_that("Unicode characters in output", {
+  bar <- "\u2551"
+  expect_success(expect_output(cat(bar), "\u2551"))
+})

--- a/tests/testthat/test-reporter.R
+++ b/tests/testthat/test-reporter.R
@@ -49,7 +49,10 @@ test_reporter <- function(reporter) {
 test_that("reporters produce consistent output", {
   save_report <- function(name, reporter = find_reporter(name)) {
     path <- test_path("reporters", paste0(name, ".txt"))
-    expect_known_output(test_reporter(reporter), path)
+    withr::with_options(
+      c(cli.unicode = TRUE),
+      expect_known_output(test_reporter(reporter), path)
+    )
   }
 
   with_mock(
@@ -97,8 +100,11 @@ expect_report_to_file <- function(name,
   # as an argument to Reporter$new() (here, via the ...), or whether it is set
   # in an option.
   path <- test_path("reporters", paste0(name, ".txt"))
-  expect_silent(test_reporter(reporter))
-  expect_equal(read_lines(output_file), read_lines(path))
+  withr::with_options(
+    c(cli.unicode = TRUE),
+    expect_silent(test_reporter(reporter))
+  )
+  expect_equal(read_lines(output_file, encoding = "unknown"), enc2native(read_lines(path)))
 }
 
 test_that("reporters accept a 'file' arugment and write to that location", {


### PR DESCRIPTION
Closes #672.

Please see the commit messages for the details of the changes.

Maybe we also want to document it that both the code files, and the reference files are expected to be UTF-8 encoded now.
