### PR TITLE
Add test for capturing in non-UTF-8 locale

### DIFF
--- a/tests/testthat/test-expect-known-output.R
+++ b/tests/testthat/test-expect-known-output.R
@@ -39,6 +39,21 @@ test_that("updates by default", {
   expect_success(expect_known_output(cat("oops"), file))
 })
 
+test_that("works in non-UTF-8 locale", {
+  text <- c("\u00fc", "\u2a5d", "\u6211", "\u0438")
+  file <- tempfile()
+  write_lines(text, file)
+
+  expect_success(expect_known_output(cat(text, sep = "\n"), file, update = FALSE))
+  withr::with_locale(
+    c(LC_CTYPE = "C"),
+    {
+      expect_false(l10n_info()$`UTF-8`)
+      expect_success(expect_known_output(cat(text, sep = "\n"), file, update = FALSE))
+    }
+  )
+})
+
 test_that("Warning for non-UTF-8 reference files", {
   x <- "\xe9\xe1\xed\xf6\xfc"
   Encoding(x) <- "latin1"


### PR DESCRIPTION
to make sure it works everywhere.