### PR TITLE
Fix #695: require at least 1.3.4 version of crayon package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Depends:
     R (>= 3.1)
 Imports: 
     cli,
-    crayon,
+    crayon (>= 1.3.4),
     digest,
     magrittr,
     methods,


### PR DESCRIPTION
#695 

col_align is used from crayon but not exported in 1.3.2 version