### PR TITLE
Print progress only if enough time has passed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,11 @@ r:
 - 3.2
 - oldrel
 - release
-- devel
+
+include:
+  matrix:
+    r: devel
+    warnings_are_errors: false
 
 after_success:
   - |

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # testthat 2.0.0.9000
 
+* ProgressReporter gains a `update_interval` parameter to control how often
+  updates are printed (default 0.1 s). This prevents large printing overhead
+  for very quick tests. (#701, @jimhester)
+
 # testthat 2.0.0
 
 ## Breaking API changes

--- a/tests/testthat/test-reporter.R
+++ b/tests/testthat/test-reporter.R
@@ -67,7 +67,7 @@ test_that("reporters produce consistent output", {
     save_report("debug")
   )
   save_report("check", CheckReporter$new(stop_on_failure = FALSE))
-  save_report("progress", ProgressReporter$new(show_praise = FALSE, min_time = Inf))
+  save_report("progress", ProgressReporter$new(show_praise = FALSE, min_time = Inf, update_interval = 0))
   save_report("summary", SummaryReporter$new(show_praise = FALSE, omit_dots = FALSE))
   save_report("summary-2", SummaryReporter$new(show_praise = FALSE, max_reports = 2))
   save_report("summary-no-dots", SummaryReporter$new(show_praise = FALSE, omit_dots = TRUE))
@@ -107,7 +107,7 @@ expect_report_to_file <- function(name,
   expect_equal(read_lines(output_file, encoding = "unknown"), enc2native(read_lines(path)))
 }
 
-test_that("reporters accept a 'file' arugment and write to that location", {
+test_that("reporters accept a 'file' argument and write to that location", {
   output <- tempfile()
   expect_report_to_file(
     "check",
@@ -116,7 +116,7 @@ test_that("reporters accept a 'file' arugment and write to that location", {
   )
   expect_report_to_file(
     "progress",
-    ProgressReporter$new(show_praise = FALSE, min_time = Inf, file = output),
+    ProgressReporter$new(show_praise = FALSE, min_time = Inf, update_interval = 0, file = output),
     output_file = output
   )
   expect_report_to_file(


### PR DESCRIPTION
Currently progress is printed after every test, which can cause a significant portion of the total test time taken to be used by printing if each test runs quickly. You also get a distracting flashing cursor when the updates occur too frequently.

As a real world example https://github.com/r-lib/fs/compare/master...sanitize adds a bunch of tests which happen very fast, the total time taken for all tests in the fs package with the current master of testthat is ~5.973 seconds. With this PR the total time drops to is 4.254 seconds, a considerable change considering it is just test printing overhead.

This PR currently reuses the min_time parameter, which seems to work ok, 1/10 of a second is a reasonable amount of time between updates. But if necessary we could add an additional option or hardcode it to some other value.