### PR TITLE
changed the expect_equal_to_reference function to hand over the updat…

### DIFF
--- a/R/expect-known.R
+++ b/R/expect-known.R
@@ -122,7 +122,7 @@ expect_known_value <- function(object, file,
 #' @rdname expect_known_output
 #' @usage NULL
 expect_equal_to_reference <- function(..., update = FALSE) {
-  expect_known_value(..., update = TRUE)
+  expect_known_value(..., update = update)
 }
 
 #' @export


### PR DESCRIPTION
The news.md states that expect_equal_to_reference is equivalent to expect_known_value, but with a default of update=FALSE. Unfortunately, the function did not hand over these update-variable to the expect_known_value function. This commit fixes that.
