### PR TITLE
Fix typo in check_reporter function

### DIFF
--- a/R/reporter.R
+++ b/R/reporter.R
@@ -92,6 +92,6 @@ default_reporter <- function() {
 
 #' @export
 #' @rdname default_reporter
-check_repoter <- function() {
+check_reporter <- function() {
   getOption("testthat.default_check_reporter", "check")
 }


### PR DESCRIPTION
Fix typo by renaming `check_repoter` function to `check_reporter`. Fixes #722