### PR TITLE
Use 3 character wide columns for successful tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,9 @@
 * Pass through warnings when `options(warn = 2)` is set (#721, @yutannihilation).
 * Progress reporter now generates a context from the filename and no longer
   errors if tests occur before a context (#700, #705).
+* The progress reporter now uses a 3 character wide column to display test
+  successes, so up to 999 successful tests can be displayed without changing
+  the alignment (#712).
 
 * `expect_lt()`, `expect_lte()`, `expect_gt()` `expect_gte()` now handle `Inf`
   and `NA` arguments appropriately (#732).

--- a/R/reporter-progress.R
+++ b/R/reporter-progress.R
@@ -90,7 +90,7 @@ ProgressReporter <- R6::R6Class("ProgressReporter",
 
     show_header = function() {
       self$cat_line(
-        cli::symbol$tick, " | OK ",
+        cli::symbol$tick, " |  OK ",
         colourise("F", "failure"), " ",
         colourise("W", "warning"), " ",
         colourise("S", "skip"), " | ",
@@ -124,7 +124,7 @@ ProgressReporter <- R6::R6Class("ProgressReporter",
 
       self$cat_tight(
         "\r",
-        status, " | ", sprintf("%2d", self$ctxt_n_ok), " ",
+        status, " | ", sprintf("%3d", self$ctxt_n_ok), " ",
         col_format(self$ctxt_n_fail, "fail"), " ",
         col_format(self$ctxt_n_warn, "warn"), " ",
         col_format(self$ctxt_n_skip, "skip"), " | ",

--- a/tests/testthat/reporters/progress.txt
+++ b/tests/testthat/reporters/progress.txt
@@ -1,17 +1,17 @@
-✔ | OK F W S | Context
+✔ |  OK F W S | Context
 
-⠏ |  0       | tests
-⠋ |  1       | tests
-✔ |  1       | tests
+⠏ |   0       | tests
+⠋ |   1       | tests
+✔ |   1       | tests
 
-⠏ |  0       | Expectations
-⠋ |  1       | Expectations
-⠙ |  1 1     | Expectations
-⠹ |  1 2     | Expectations
-⠸ |  1 3     | Expectations
-⠼ |  1 4     | Expectations
-⠴ |  2 4     | Expectations
-✖ |  2 4     | Expectations
+⠏ |   0       | Expectations
+⠋ |   1       | Expectations
+⠙ |   1 1     | Expectations
+⠹ |   1 2     | Expectations
+⠸ |   1 3     | Expectations
+⠼ |   1 4     | Expectations
+⠴ |   2 4     | Expectations
+✖ |   2 4     | Expectations
 ────────────────────────────────────────────────────────────────────────────────
 tests.R:12: failure: Failure:1
 Failure has been forced
@@ -28,13 +28,13 @@ tests.R:24: failure: Failure:loop
 [1] 1 - 2 == -1
 ────────────────────────────────────────────────────────────────────────────────
 
-⠏ |  0       | Expectations2
-✔ |  0       | Expectations2
+⠏ |   0       | Expectations2
+✔ |   0       | Expectations2
 
-⠏ |  0       | Errors
-⠋ |  0 1     | Errors
-⠙ |  0 2     | Errors
-✖ |  0 2     | Errors
+⠏ |   0       | Errors
+⠋ |   0 1     | Errors
+⠙ |   0 2     | Errors
+✖ |   0 2     | Errors
 ────────────────────────────────────────────────────────────────────────────────
 tests.R:33: error: Error:1
 stop
@@ -48,9 +48,9 @@ tests.R:47: error: Error:3
 4: stop("!") at reporters/tests.R:44
 ────────────────────────────────────────────────────────────────────────────────
 
-⠏ |  0       | Recursion
-⠋ |  0 1     | Recursion
-✖ |  0 1     | Recursion
+⠏ |   0       | Recursion
+⠋ |   0 1     | Recursion
+✖ |   0 1     | Recursion
 ────────────────────────────────────────────────────────────────────────────────
 tests.R:56: error: Recursion:1
 This is deep
@@ -77,11 +77,11 @@ This is deep
 27: stop("This is deep") at reporters/tests.R:54
 ────────────────────────────────────────────────────────────────────────────────
 
-⠏ |  0       | Skips
-⠋ |  0     1 | Skips
-⠙ |  0     2 | Skips
-⠹ |  0     3 | Skips
-✔ |  0     3 | Skips
+⠏ |   0       | Skips
+⠋ |   0     1 | Skips
+⠙ |   0     2 | Skips
+⠹ |   0     3 | Skips
+✔ |   0     3 | Skips
 ────────────────────────────────────────────────────────────────────────────────
 tests.R:62: skip: Skip:1
 skip
@@ -93,11 +93,11 @@ tests.R:72: skip: Skip:3
 Empty test
 ────────────────────────────────────────────────────────────────────────────────
 
-⠏ |  0       | Warnings
-⠋ |  0   1   | Warnings
-⠙ |  0   2   | Warnings
-⠹ |  0   3   | Warnings
-✔ |  0   3   | Warnings
+⠏ |   0       | Warnings
+⠋ |   0   1   | Warnings
+⠙ |   0   2   | Warnings
+⠹ |   0   3   | Warnings
+✔ |   0   3   | Warnings
 ────────────────────────────────────────────────────────────────────────────────
 tests.R:78: warning: Warning:1
 abc
@@ -109,13 +109,13 @@ tests.R:85: warning: Warning:2
 ghi
 ────────────────────────────────────────────────────────────────────────────────
 
-⠏ |  0       | Output
-⠋ |  1       | Output
-⠙ |  2       | Output
-✔ |  2       | Output
+⠏ |   0       | Output
+⠋ |   1       | Output
+⠙ |   2       | Output
+✔ |   2       | Output
 
-⠏ |  0       | End
-✔ |  0       | End
+⠏ |   0       | End
+✔ |   0       | End
 
 ══ Results ═════════════════════════════════════════════════════════════════════
 OK:       5


### PR DESCRIPTION
This is a simple solution to the problem of more than 100 successful tests messing up the column alignment. I don't know if we want to try and do something more sophisticated, or if this is sufficient to handle the majority of cases.

FIxes #712