### PR TITLE
modifying condition to get encoding deprecation message

### DIFF
--- a/R/test-directory.R
+++ b/R/test-directory.R
@@ -65,7 +65,7 @@ test_dir <- function(path,
                      stop_on_failure = FALSE,
                      stop_on_warning = FALSE,
                      wrap = TRUE) {
-  if (!missing(encoding) && !identical(encoding, "UTF-8")) {
+  if (!identical(encoding, "unknown")) {
     warning("`encoding` is deprecated; all files now assumed to be UTF-8", call. = FALSE)
   }
 


### PR DESCRIPTION
Issue #754 complains about the message:
```
`encoding` is deprecated; all files now assumed to be UTF-8 
```
which has been appearing lately when using `devtools::test()`.  @kenahoo suggested checking for the encoding argument only if  `testthat` is less than a particular version.  I thought about that but noticed a few different things during experimentation with `devtools::test()`:

- If no encoding is specified in the DESCRIPTION file, encoding gets set to "unknown" in `testthat::test_dir` and `missing(encoding)` returns `FALSE`, thus triggering the message (and feels "out of the blue")
- One way to silence the message is to add "ENCODING: UTF-8" in the DESCRIPTION file, because only then is encoding both not missing and identical to "UTF-8".
- Any other valid encoding also triggers the message, and invalid encodings produce errors before this warning message is ever encountered.

If the encoding field really is meant to be deprecated, I feel that you should get the warning even if you specified an encoding of UTF-8. According to [Writing R Extensions](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#The-DESCRIPTION-file), there is reason not to do this as it makes the package "less portable."

Thus, the very small change proposed in this pull request triggers the warning message when and only when a package's DESCRIPTION file specifies an encoding, no matter what that encoding is.