### PR TITLE
Support for wildcard in expect_known_output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,6 +62,7 @@ Collate:
     'expectation.R'
     'expectations-matches.R'
     'make-expectation.R'
+    'match.R'
     'mock.R'
     'old-school.R'
     'praise.R'

--- a/R/match.R
+++ b/R/match.R
@@ -1,0 +1,24 @@
+match <- function (act, ref, wildcard,
+                   max_diffs = 5, max_lines = 5,
+                   width = cli::console_width()) {
+  stopifnot(length(act) == length(ref))
+  stopifnot(is.character(wildcard), identical(length(wildcard), 1L))
+
+  same <- unlist(Map(a = act, r = ref, f = function (a, r) {
+    r <- escape_regex(r)
+    r <- gsub(wildcard, '.*', r, fixed = TRUE)
+    grepl(paste0('^', r, '$'), a)
+  }))
+
+  if (all(same)) {
+    no_difference()
+  } else {
+    mismatches <- mismatch_character(act, ref, !same)
+    difference(format(
+      mismatches,
+      max_diffs = max_diffs,
+      max_lines = max_lines,
+      width = width
+    ))
+  }
+}

--- a/man/expect_known_output.Rd
+++ b/man/expect_known_output.Rd
@@ -8,8 +8,8 @@
 \alias{expect_known_hash}
 \title{Expectations: is the output or the value equal to a known good value?}
 \usage{
-expect_known_output(object, file, update = TRUE, ..., info = NULL,
-  label = NULL, print = FALSE, width = 80)
+expect_known_output(object, file, update = TRUE, wildcard = NULL, ...,
+  info = NULL, label = NULL, print = FALSE, width = 80)
 
 expect_known_value(object, file, update = TRUE, ..., info = NULL,
   label = NULL)
@@ -24,6 +24,9 @@ expect_known_hash(object, hash = NULL)
 \item{update}{Should the file be updated? Defaults to \code{TRUE}, with
 the expectation that you'll notice changes because of the first failure,
 and then see the modified files in git.}
+
+\item{wildcard}{Character matching arbitrary string, without a new line.
+By default there is no wildcard.}
 
 \item{...}{other values passed to \code{\link[=all.equal]{all.equal()}} or \code{[identical()]}.}
 
@@ -65,7 +68,7 @@ tmp <- tempfile()
 # The first run always succeeds
 expect_known_output(mtcars[1:10, ], tmp, print = TRUE)
 
-# Subsequent runs will suceed only if the file is unchanged
+# Subsequent runs will succeed only if the file is unchanged
 # This will succeed:
 expect_known_output(mtcars[1:10, ], tmp, print = TRUE)
 
@@ -73,4 +76,7 @@ expect_known_output(mtcars[1:10, ], tmp, print = TRUE)
 # This will fail
 expect_known_output(mtcars[1:9, ], tmp, print = TRUE)
 }
+
+writeLines('a\%e', tmp)
+expect_known_output(cat('abcde'), tmp, wildcard = '\%')
 }

--- a/tests/testthat/test-expect-known-output.R
+++ b/tests/testthat/test-expect-known-output.R
@@ -66,3 +66,17 @@ test_that("Warning for non-UTF-8 reference files", {
     expect_warning(expect_known_output("foobar", tmp, update = FALSE))
   )
 })
+
+test_that("accepts wildcard", {
+  file <- tempfile()
+  write_lines("a%e", file)
+  expect_success(expect_known_output(cat("abcde"), file, wildcard = '%'))
+  expect_equal(read_lines(file), "a%e")
+})
+
+test_that("updates if wildcard does not match", {
+  file <- tempfile()
+  write_lines("a%e", file)
+  expect_failure(expect_known_output(cat("abcd"), file, wildcard = '%'))
+  expect_equal(read_lines(file), "abcd")
+})

--- a/tests/testthat/test-match.R
+++ b/tests/testthat/test-match.R
@@ -1,0 +1,24 @@
+context("match")
+
+test_that("basic wildcard works", {
+  expect_true(match('abcde', 'a%e', '%')$equal)
+})
+
+test_that("full line match", {
+  expect_false(match('abcde', 'a%d', '%')$equal)
+})
+
+test_that("only differences are shown", {
+  x <- match(paste0(letters, 'xyz', letters),
+             paste0(letters, '%', c(letters[-26], "a")),
+             '%')$message
+
+  lines <- strsplit(format(x), "\n")[[1]]
+  expect_equal(lines[1], "1/26 mismatches")
+  expect_equal(lines[2], 'x[26]: "zxyzz"')
+  expect_equal(lines[3], 'y[26]: "z%a"')
+})
+
+test_that("special characters are escaped", {
+  expect_true(match('a#()[]bc', 'a#()[]%c', '%')$equal)
+})


### PR DESCRIPTION
* new argument for `expect_known_output`: `wildcard` accepts a single character matched against an arbitrary string; by default it is `NULL` which means no wildcard
* new matching algorithm in `match.R` and its tests in `test-match.R`
* new tests for and examples for `expect_known_output`