### PR TITLE
Expose chdir arguments in test functions

### DIFF
--- a/R/auto-test.R
+++ b/R/auto-test.R
@@ -27,10 +27,11 @@
 #' @param env environment in which to execute test suite.
 #' @param hash Passed on to [watch()]. When FALSE, uses less accurate
 #'   modification time stamps, but those are faster for large files.
+#' @inheritParams test_dir
 #' @keywords debugging
 auto_test <- function(code_path, test_path, reporter = default_reporter(),
                       env = test_env(),
-                      hash = TRUE) {
+                      hash = TRUE, chdir = TRUE) {
   reporter <- find_reporter(reporter)
   code_path <- normalizePath(code_path)
   test_path <- normalizePath(test_path)
@@ -55,7 +56,7 @@ auto_test <- function(code_path, test_path, reporter = default_reporter(),
     } else if (length(tests) > 0) {
       # If test changes, rerun just that test
       cat("Rerunning tests: ", paste0(basename(tests), collapse = ", "), "\n")
-      test_files(tests, env = env, reporter = reporter$clone(deep = TRUE))
+      test_files(tests, env = env, reporter = reporter$clone(deep = TRUE), chdir = chdir)
     }
 
     TRUE
@@ -70,9 +71,11 @@ auto_test <- function(code_path, test_path, reporter = default_reporter(),
 #' @param reporter test reporter to use
 #' @param hash Passed on to [watch()].  When FALSE, uses less accurate
 #'   modification time stamps, but those are faster for large files.
+#' @inheritParams test_package
 #' @keywords debugging
 #' @seealso [auto_test()] for details on how method works
-auto_test_package <- function(pkg = ".", reporter = default_reporter(), hash = TRUE) {
+auto_test_package <- function(pkg = ".", reporter = default_reporter(),
+                              hash = TRUE, chdir = chdir) {
   if (!requireNamespace("devtools", quietly = TRUE)) {
     stop(
       "devtools required to run auto_test_package(). Please install.",
@@ -107,14 +110,16 @@ auto_test_package <- function(pkg = ".", reporter = default_reporter(), hash = T
       env <<- devtools::load_all(pkg, quiet = TRUE)$env
       withr::with_envvar(
         devtools::r_env_vars(),
-        test_dir(test_path, env = env, reporter = reporter$clone(deep = TRUE))
+        test_dir(test_path, env = env,
+                 reporter = reporter$clone(deep = TRUE), chdir = chdir)
       )
     } else if (length(tests) > 0) {
       # If test changes, rerun just that test
       cat("Rerunning tests: ", paste0(basename(tests), collapse = ", "), "\n")
       withr::with_envvar(
         devtools::r_env_vars(),
-        test_files(tests, env = env, reporter = reporter$clone(deep = TRUE))
+        test_files(tests, env = env,
+                   reporter = reporter$clone(deep = TRUE), chdir = chdir)
       )
     }
 

--- a/R/test-directory.R
+++ b/R/test-directory.R
@@ -64,7 +64,9 @@ test_dir <- function(path,
                      load_helpers = TRUE,
                      stop_on_failure = FALSE,
                      stop_on_warning = FALSE,
-                     wrap = TRUE) {
+                     wrap = TRUE,
+                     chdir = TRUE
+                     ) {
   if (!missing(encoding) && !identical(encoding, "UTF-8")) {
     warning("`encoding` is deprecated; all files now assumed to be UTF-8", call. = FALSE)
   }
@@ -90,7 +92,8 @@ test_dir <- function(path,
     env = env,
     stop_on_failure = stop_on_failure,
     stop_on_warning = stop_on_warning,
-    wrap = wrap
+    wrap = wrap,
+    chdir = chdir
   )
 }
 
@@ -101,7 +104,8 @@ test_package <- function(package,
                          reporter = check_reporter(),
                          ...,
                          stop_on_failure = TRUE,
-                         stop_on_warning = FALSE) {
+                         stop_on_warning = FALSE,
+                         chdir = TRUE) {
   library(testthat)
 
   # Ensure that test package returns silently if called recursively - this
@@ -141,7 +145,8 @@ test_package <- function(package,
     reporter = reporter,
     ...,
     stop_on_failure = stop_on_failure,
-    stop_on_warning = stop_on_warning
+    stop_on_warning = stop_on_warning,
+    chdir = chdir
   )
 }
 
@@ -153,7 +158,8 @@ test_check <- function(package,
                        ...,
                        stop_on_failure = TRUE,
                        stop_on_warning = FALSE,
-                       wrap = TRUE) {
+                       wrap = TRUE,
+                       chdir = TRUE) {
   library(testthat)
   require(package, character.only = TRUE)
 
@@ -177,14 +183,15 @@ test_check <- function(package,
     ...,
     stop_on_failure = stop_on_failure,
     stop_on_warning = stop_on_warning,
-    wrap = wrap
+    wrap = wrap,
+    chdir = chdir
   )
 }
 
 test_package_dir <- function(package, test_path, filter, reporter, ...,
                              stop_on_failure = TRUE,
                              stop_on_warning = FALSE,
-                             wrap = TRUE) {
+                             wrap = TRUE, chdir = TRUE) {
   env <- test_pkg_env(package)
   withr::local_options(list(topLevelEnvironment = env))
 
@@ -197,7 +204,8 @@ test_package_dir <- function(package, test_path, filter, reporter, ...,
     ...,
     stop_on_failure = stop_on_failure,
     stop_on_warning = stop_on_warning,
-    wrap = wrap
+    wrap = wrap,
+    chdir = chdir
   )
 }
 

--- a/R/test-files.R
+++ b/R/test-files.R
@@ -16,7 +16,9 @@ test_files <- function(paths,
                        env = test_env(),
                        stop_on_failure = FALSE,
                        stop_on_warning = FALSE,
-                       wrap = TRUE) {
+                       wrap = TRUE,
+                       chdir = TRUE
+                       ) {
   if (length(paths) == 0) {
     stop("No matching test file in dir")
   }
@@ -31,7 +33,8 @@ test_files <- function(paths,
       reporter = current_reporter,
       start_end_reporter = FALSE,
       load_helpers = FALSE,
-      wrap = wrap
+      wrap = wrap,
+      chdir = chdir
     )
   )
 
@@ -95,7 +98,7 @@ find_test_scripts <- function(path, filter = NULL, invert = FALSE, ...) {
 #' @export
 test_file <- function(path, reporter = default_reporter(), env = test_env(),
                       start_end_reporter = TRUE, load_helpers = TRUE,
-                      encoding = "unknown", wrap = TRUE) {
+                      encoding = "unknown", wrap = TRUE, chdir = TRUE) {
   library(testthat)
 
   if (!file.exists(path)) {
@@ -133,7 +136,7 @@ test_file <- function(path, reporter = default_reporter(), env = test_env(),
 
       source_file(
         path, new.env(parent = env),
-        chdir = TRUE, wrap = wrap
+        chdir = chdir, wrap = wrap
       )
 
       end_context()

--- a/man/auto_test.Rd
+++ b/man/auto_test.Rd
@@ -5,7 +5,7 @@
 \title{Watches code and tests for changes, rerunning tests as appropriate.}
 \usage{
 auto_test(code_path, test_path, reporter = default_reporter(),
-  env = test_env(), hash = TRUE)
+  env = test_env(), hash = TRUE, chdir = TRUE)
 }
 \arguments{
 \item{code_path}{path to directory containing code}
@@ -18,6 +18,8 @@ auto_test(code_path, test_path, reporter = default_reporter(),
 
 \item{hash}{Passed on to \code{\link[=watch]{watch()}}. When FALSE, uses less accurate
 modification time stamps, but those are faster for large files.}
+
+\item{chdir}{Change working directory to \code{dirname(path)}?}
 }
 \description{
 The idea behind \code{auto_test()} is that you just leave it running while

--- a/man/auto_test_package.Rd
+++ b/man/auto_test_package.Rd
@@ -4,7 +4,8 @@
 \alias{auto_test_package}
 \title{Watches a package for changes, rerunning tests as appropriate.}
 \usage{
-auto_test_package(pkg = ".", reporter = default_reporter(), hash = TRUE)
+auto_test_package(pkg = ".", reporter = default_reporter(), hash = TRUE,
+  chdir = chdir)
 }
 \arguments{
 \item{pkg}{path to package}
@@ -13,6 +14,8 @@ auto_test_package(pkg = ".", reporter = default_reporter(), hash = TRUE)
 
 \item{hash}{Passed on to \code{\link[=watch]{watch()}}.  When FALSE, uses less accurate
 modification time stamps, but those are faster for large files.}
+
+\item{chdir}{Change working directory to \code{dirname(path)}?}
 }
 \description{
 Watches a package for changes, rerunning tests as appropriate.

--- a/man/test_dir.Rd
+++ b/man/test_dir.Rd
@@ -10,13 +10,15 @@
 \usage{
 test_dir(path, filter = NULL, reporter = default_reporter(),
   env = test_env(), ..., encoding = "unknown", load_helpers = TRUE,
-  stop_on_failure = FALSE, stop_on_warning = FALSE, wrap = TRUE)
+  stop_on_failure = FALSE, stop_on_warning = FALSE, wrap = TRUE,
+  chdir = TRUE)
 
 test_package(package, filter = NULL, reporter = check_reporter(), ...,
-  stop_on_failure = TRUE, stop_on_warning = FALSE)
+  stop_on_failure = TRUE, stop_on_warning = FALSE, chdir = TRUE)
 
 test_check(package, filter = NULL, reporter = check_reporter(), ...,
-  stop_on_failure = TRUE, stop_on_warning = FALSE, wrap = TRUE)
+  stop_on_failure = TRUE, stop_on_warning = FALSE, wrap = TRUE,
+  chdir = TRUE)
 
 is_testing()
 
@@ -47,6 +49,8 @@ warnings.}
 
 \item{wrap}{Automatically wrap all code within \code{\link[=test_that]{test_that()}}? This ensures
 that all expectations are reported, even if outside a test block.}
+
+\item{chdir}{Change working directory to \code{dirname(path)}?}
 
 \item{package}{package name}
 }

--- a/man/test_file.Rd
+++ b/man/test_file.Rd
@@ -6,7 +6,7 @@
 \usage{
 test_file(path, reporter = default_reporter(), env = test_env(),
   start_end_reporter = TRUE, load_helpers = TRUE, encoding = "unknown",
-  wrap = TRUE)
+  wrap = TRUE, chdir = TRUE)
 }
 \arguments{
 \item{path}{path to file}
@@ -24,6 +24,8 @@ test_file(path, reporter = default_reporter(), env = test_env(),
 
 \item{wrap}{Automatically wrap all code within \code{\link[=test_that]{test_that()}}? This ensures
 that all expectations are reported, even if outside a test block.}
+
+\item{chdir}{Change working directory to \code{dirname(path)}?}
 }
 \value{
 the results as a "testthat_results" (list)


### PR DESCRIPTION
Sometimes you don't want to run tests in the environment
where those files are. For example users may not have write
access to an R package installation directory but still
want to run tests that require file IO. This commit
exposes the `chdir` option of `source_file` to test
runner functions. Can be disabled to run tests in the
current working directory.