### PR TITLE
Improve junit time format compatibility

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,8 @@
 * `expect_lt()` and friends now work with any object that defines the
   appropriate comparison method. (#777)
 
+* improve junit xml compatibility for jenkins. (#806, @comicfans)
+
 # testthat 2.0.1
 
 * Fix failing tests with devtools 2.0.0

--- a/R/reporter-junit.R
+++ b/R/reporter-junit.R
@@ -91,7 +91,8 @@ JunitReporter <- R6::R6Class("JunitReporter",
       xml2::xml_attr(self$suite, "skipped") <- as.character(self$skipped)
       xml2::xml_attr(self$suite, "failures") <- as.character(self$failures)
       xml2::xml_attr(self$suite, "errors") <- as.character(self$errors)
-      xml2::xml_attr(self$suite, "time") <- as.character(self$suite_time)
+      #jenkins junit plugin requires time has at most 3 digits
+      xml2::xml_attr(self$suite, "time") <- as.character(round(self$suite_time, 3))
 
       self$reset_suite()
     },


### PR DESCRIPTION
Jenkins junit plugin requires time has at most 3 digits, or it reports 

```
junit.xml:cvc-pattern-valid: Value '5.44999999999999' is not facet-valid with respect to pattern '(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})*(\.[0-9]{0,3})?' for type 'SUREFIRE_TIME'.
```