### PR TITLE
Adding 'info' parameter to comparison tests for consistency with other functions

### DIFF
--- a/R/expect-comparison.R
+++ b/R/expect-comparison.R
@@ -20,7 +20,8 @@
 #' @name comparison-expectations
 NULL
 
-expect_compare <- function(operator = c("<", "<=", ">", ">="), act, exp) {
+expect_compare <- function(operator = c("<", "<=", ">", ">="), act, exp,
+                           info = NULL) {
   operator <- match.arg(operator)
   op <- match.fun(operator)
 
@@ -37,44 +38,50 @@ expect_compare <- function(operator = c("<", "<=", ">", ">="), act, exp) {
   cmp <- op(act$val, exp$val)
   expect(
     if (!is.na(cmp)) cmp else FALSE,
-    sprintf("%s is %s %s. Difference: %.3g", act$lab, msg, exp$lab, act$val - exp$val)
+    sprintf("%s is %s %s. Difference: %.3g", act$lab, msg, exp$lab, act$val - exp$val),
+    info = info
   )
   invisible(act$val)
 }
+
 #' @export
 #' @rdname comparison-expectations
-expect_lt <- function(object, expected, label = NULL, expected.label = NULL) {
+expect_lt <- function(object, expected, label = NULL, expected.label = NULL,
+                      info = NULL) {
   act <- quasi_label(enquo(object), label)
   exp <- quasi_label(enquo(expected), expected.label)
 
-  expect_compare("<", act, exp)
+  expect_compare("<", act, exp, info = info)
 }
 
 #' @export
 #' @rdname comparison-expectations
-expect_lte <- function(object, expected, label = NULL, expected.label = NULL) {
+expect_lte <- function(object, expected, label = NULL, expected.label = NULL,
+                       info = NULL) {
   act <- quasi_label(enquo(object), label)
   exp <- quasi_label(enquo(expected), expected.label)
 
-  expect_compare("<=", act, exp)
+  expect_compare("<=", act, exp, info = info)
 }
 
 #' @export
 #' @rdname comparison-expectations
-expect_gt <- function(object, expected, label = NULL, expected.label = NULL) {
+expect_gt <- function(object, expected, label = NULL, expected.label = NULL,
+                      info = NULL) {
   act <- quasi_label(enquo(object), label)
   exp <- quasi_label(enquo(expected), expected.label)
 
-  expect_compare(">", act, exp)
+  expect_compare(">", act, exp, info = info)
 }
 
 #' @export
 #' @rdname comparison-expectations
-expect_gte <- function(object, expected, label = NULL, expected.label = NULL) {
+expect_gte <- function(object, expected, label = NULL, expected.label = NULL,
+                       info = NULL) {
   act <- quasi_label(enquo(object), label)
   exp <- quasi_label(enquo(expected), expected.label)
 
-  expect_compare(">=", act, exp)
+  expect_compare(">=", act, exp, info = info)
 }
 
 

--- a/tests/testthat/test-comparisons.R
+++ b/tests/testthat/test-comparisons.R
@@ -40,3 +40,15 @@ test_that("comparisons with more complicated objects work", {
   expect_success(expect_gt(time2, time))
   expect_success(expect_gte(time2, time))
 })
+
+test_that("info parameters are preserved", {
+  msg = "ImPrObAbLe"
+  expect_error(expect_lt(10, 10, info = msg),
+               regexp = msg)
+  expect_error(expect_lte(20, 10, info = msg),
+               regexp = msg)
+  expect_error(expect_gt(10, 10, info = msg),
+               regexp = msg)
+  expect_error(expect_gte(10, 20, info = msg),
+               regexp = msg)
+})


### PR DESCRIPTION
- Add `info` parameter to `expect_lt`, `expect_lte`, `expect_gt`, and `expect_gte`.
- Modify `expect_compare` to pass through.
- Add tests to ensure that value of `info` parameter shows up in output.