### PR TITLE
Define a generic for identical() so custom methods can be utilized

### DIFF
--- a/R/expect-equality.R
+++ b/R/expect-equality.R
@@ -97,6 +97,8 @@ expect_equivalent <- function(object, expected, ..., info = NULL, label = NULL,
   invisible(act$val)
 }
 
+setGeneric("identical")
+
 #' @export
 #' @rdname equality-expectations
 expect_identical <- function(object, expected, info = NULL, label = NULL,


### PR DESCRIPTION
This fixes #820.