### PR TITLE
Use sha1 instead of digest to overcome precision errors

### DIFF
--- a/R/expect-known.R
+++ b/R/expect-known.R
@@ -131,7 +131,7 @@ expect_equal_to_reference <- function(..., update = FALSE) {
 #'   to use in the test output.
 expect_known_hash <- function(object, hash = NULL) {
   act <- quasi_label(enquo(object))
-  act_hash <- digest::digest(act$val)
+  act_hash <- digest::sha1(act$val)
   if (!is.null(hash)) {
     act_hash <- substr(act_hash, 1, nchar(hash))
   }

--- a/tests/testthat/test-expect-known-hash.R
+++ b/tests/testthat/test-expect-known-hash.R
@@ -10,6 +10,6 @@ test_that("empty hash succeeds with warning", {
 })
 
 test_that("only succeeds if hash is correct", {
-  expect_success(expect_known_hash(1:10, "c08951d2c2"))
+  expect_success(expect_known_hash(1:10, "65e11d78de"))
   expect_failure(expect_known_hash(1:10, "c08951d2c3"))
 })


### PR DESCRIPTION
Currently `expect_known_hash` does not work on different computer / OS because of floating precision error.

According to [the digest vignette](https://cran.r-project.org/web/packages/digest/vignettes/sha1.html), in this case, we should use `sha1()` instead of `digest()`. This PR performs this change.

I can revise it if necessary! Also, I'm not sure under which section this should be added to `NEWS.md`. This change will require users to update their hash values.