### PR TITLE
Add check.attributes argument to compare.POSIXt

### DIFF
--- a/R/compare-time.R
+++ b/R/compare-time.R
@@ -1,6 +1,6 @@
 #' @rdname compare
 #' @export
-compare.POSIXt <- function(x, y, tolerance = 0.001, ..., max_diffs = 9) {
+compare.POSIXt <- function(x, y, tolerance = 0.001, check.attributes = T, ..., max_diffs = 9) {
   if (!inherits(y, "POSIXt")) {
     return(diff_class(x, y))
   }
@@ -11,7 +11,7 @@ compare.POSIXt <- function(x, y, tolerance = 0.001, ..., max_diffs = 9) {
   x <- standardise_tzone(as.POSIXct(x))
   y <- standardise_tzone(as.POSIXct(y))
 
-  if (!same_attr(x, y)) {
+  if (check.attributes && !same_attr(x, y)) {
     return(diff_attr(x, y))
   }
 

--- a/tests/testthat/test-compare-time.R
+++ b/tests/testthat/test-compare-time.R
@@ -45,3 +45,12 @@ test_that("uses all.equal tolerance", {
   x2 <- structure(1457284588.837, class = c("POSIXct", "POSIXt"))
   expect_true(compare(x1, x2)$equal)
 })
+
+test_that("check.attributes", {
+  x = as.POSIXct('2016-1-1')
+  y = x
+  attr(y, 'tclass') = attr(y, 'class')
+  expect_false(compare(x, y, check.attributes = T)$equal)
+  expect_true(compare(x, y, check.attributes = F)$equal)
+  expect_equal(compare(x, y, check.attributes = F)$message, "Equal")
+})


### PR DESCRIPTION
POSIXct objects created by some objects, such as the index of xts objects, contain additional attributes.  For example the POSIXct objects in the index() of an xts object will contain the 'tclass' attribute.  This is make it difficult to compare POSIXct objects.  Adding the check.attributes argument allows POSIXct objects to be compared by their numeric values.