### PR TITLE
handle named R lists in expect_setequal (#750)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,9 @@
 
 ## Minor improvements and bug fixes
 
+* `expect_setequal()` now accepts named R lists for comparison -- the lists
+  are reordered according to their names (#750).
+
 * Fixed an issue where `devtools::test()` could fail if run multiple times
   within the same R session for a package containing Catch tests.
   ([devtools #1832](https://github.com/r-lib/devtools/issues/1832))

--- a/R/expect-equality.R
+++ b/R/expect-equality.R
@@ -68,8 +68,8 @@ expect_setequal <- function(object, expected) {
   act <- quasi_label(enquo(object))
   exp <- quasi_label(enquo(expected))
 
-  act$val <- sort(unique(act$val))
-  exp$val <- sort(unique(exp$val))
+  act$val <- sort_unique(act$val)
+  exp$val <- sort_unique(exp$val)
 
   comp <- compare(act$val, exp$val)
   expect(

--- a/R/utils.R
+++ b/R/utils.R
@@ -27,6 +27,13 @@ first_last <- function(x, max = 10, filler = "...") {
   }
 }
 
+sort_unique <- function(x) {
+  if (is.list(x))
+    x[sort(unique(names(x)))]
+  else
+    sort(unique(x))
+}
+
 # Tools for finding srcrefs -----------------------------------------------
 
 show_stack <- function(star = integer(), n = sys.nframe() - 1L) {

--- a/tests/testthat/test-expect-equality.R
+++ b/tests/testthat/test-expect-equality.R
@@ -66,3 +66,7 @@ test_that("expect_setequal ignores order and duplicates", {
 test_that("expect_setequal doesn't ignore genuine differnces", {
   expect_failure(expect_setequal(letters, letters[-1]))
 })
+
+test_that("expect_setequal accepts named lists", {
+  expect_setequal(list(a = 1, b = 2), list(b = 2, a = 1))
+})


### PR DESCRIPTION
Useful for when you're treating the two lists as property bags and order doesn't matter.