### PR TITLE
Fixes for expect_mapequal

### DIFF
--- a/R/expect-setequal.R
+++ b/R/expect-setequal.R
@@ -78,8 +78,31 @@ expect_mapequal <- function(object, expected) {
     abort("`object` and `expected` must both be vectors")
   }
 
+  # Length-0 vectors are OK whether named or unnamed.
+  if (length(act$val) == 0 && length(exp$val) == 0) {
+    succeed()
+  }
+
   act_nms <- names(act$val)
   exp_nms <- names(exp$val)
+
+  if (anyDuplicated(act_nms)) {
+    fail(
+      paste0("Duplicate names in `object`: ", unique(act_nms[duplicated(act_nms)]))
+    )
+  }
+  if (anyDuplicated(exp_nms)) {
+    fail(
+      paste0("Duplicate names in `expected`: ", unique(exp_nms[duplicated(exp_nms)]))
+    )
+  }
+  if (any(act_nms == "")) {
+    fail(paste0("All elements in `object` must be named"))
+  }
+  if (any(exp_nms == "")) {
+    fail(paste0("All elements in `expected` must be named"))
+  }
+
 
   if (!setequal(act_nms, exp_nms)) {
     act_miss <- setdiff(exp_nms, act_nms)

--- a/R/expect-setequal.R
+++ b/R/expect-setequal.R
@@ -82,28 +82,15 @@ expect_mapequal <- function(object, expected) {
   if (length(act$val) == 0 && length(exp$val) == 0) {
     warn("`object` and `expected` are empty lists")
     succeed()
+    return(invisible(act$val))
   }
 
   act_nms <- names(act$val)
   exp_nms <- names(exp$val)
 
-  if (anyDuplicated(act_nms)) {
-    fail(
-      paste0("Duplicate names in `object`: ", unique(act_nms[duplicated(act_nms)]))
-    )
+  if (!names_ok(act_nms, "object") || !names_ok(exp_nms, "expected")) {
+    return(act$val)
   }
-  if (anyDuplicated(exp_nms)) {
-    fail(
-      paste0("Duplicate names in `expected`: ", unique(exp_nms[duplicated(exp_nms)]))
-    )
-  }
-  if (any(act_nms == "")) {
-    fail(paste0("All elements in `object` must be named"))
-  }
-  if (any(exp_nms == "")) {
-    fail(paste0("All elements in `expected` must be named"))
-  }
-
 
   if (!setequal(act_nms, exp_nms)) {
     act_miss <- setdiff(exp_nms, act_nms)
@@ -122,4 +109,21 @@ expect_mapequal <- function(object, expected) {
   }
 
   invisible(act$val)
+}
+
+names_ok <- function(x, label) {
+  ok <- TRUE
+
+  if (anyDuplicated(x)) {
+    ok <- FALSE
+    fail(
+      paste0("Duplicate names in `", label, "`: ", unique(x[duplicated(x)]))
+    )
+  }
+  if (any(x == "")) {
+    ok <- FALSE
+    fail(paste0("All elements in `", label, "` must be named"))
+  }
+
+  ok
 }

--- a/R/expect-setequal.R
+++ b/R/expect-setequal.R
@@ -88,9 +88,8 @@ expect_mapequal <- function(object, expected) {
   act_nms <- names(act$val)
   exp_nms <- names(exp$val)
 
-  if (!names_ok(act_nms, "object") || !names_ok(exp_nms, "expected")) {
-    return(act$val)
-  }
+  check_names_ok(act_nms, "object")
+  check_names_ok(exp_nms, "expected")
 
   if (!setequal(act_nms, exp_nms)) {
     act_miss <- setdiff(exp_nms, act_nms)
@@ -111,19 +110,11 @@ expect_mapequal <- function(object, expected) {
   invisible(act$val)
 }
 
-names_ok <- function(x, label) {
-  ok <- TRUE
-
+check_names_ok <- function(x, label) {
   if (anyDuplicated(x)) {
-    ok <- FALSE
-    fail(
-      paste0("Duplicate names in `", label, "`: ", unique(x[duplicated(x)]))
-    )
+    stop("Duplicate names in `", label, "`: ", unique(x[duplicated(x)]))
   }
   if (any(x == "")) {
-    ok <- FALSE
-    fail(paste0("All elements in `", label, "` must be named"))
+    stop("All elements in `", label, "` must be named")
   }
-
-  ok
 }

--- a/R/expect-setequal.R
+++ b/R/expect-setequal.R
@@ -80,6 +80,7 @@ expect_mapequal <- function(object, expected) {
 
   # Length-0 vectors are OK whether named or unnamed.
   if (length(act$val) == 0 && length(exp$val) == 0) {
+    warn("`object` and `expected` are empty lists")
     succeed()
   }
 

--- a/tests/testthat/test-expect-setequal.R
+++ b/tests/testthat/test-expect-setequal.R
@@ -29,6 +29,16 @@ test_that("ignores order", {
   expect_success(expect_mapequal(list(a = 1, b = 2), list(b = 2, a = 1)))
 })
 
+test_that("fails if any names are duplicated", {
+  expect_failure(expect_mapequal(list(a = 1, b = 2, b = 3), list(b = 2, a = 1)))
+  expect_failure(expect_mapequal(list(a = 1, b = 2), list(b = 3, b = 2, a = 1)))
+  expect_failure(expect_mapequal(list(a = 1, b = 2, b = 3), list(b = 3, b = 2, a = 1)))
+})
+
+test_that("handling NULLs", {
+  expect_success(expect_mapequal(list(a = 1, b = NULL), list(b = NULL, a = 1)))
+})
+
 test_that("fail if names don't match", {
   expect_failure(expect_mapequal(list(a = 1, b = 2), list(a = 1)))
   expect_failure(expect_mapequal(list(a = 1), list(a = 1, b = 2)))
@@ -40,4 +50,18 @@ test_that("fails if values don't match", {
 
 test_that("error for non-vectors", {
   expect_error(expect_mapequal(sum, sum), "be vectors")
+  expect_error(expect_mapequal(NULL, NULL), "be vectors")
+})
+
+test_that("fails if any unnamed values", {
+  expect_failure(expect_mapequal(list(1, b = 2), list(1, b = 2)))
+  expect_failure(expect_mapequal(list(1, b = 2), list(b = 2, 1)))
+})
+
+test_that("succeeds if comparing empty named and unnamed vectors", {
+  expect_success(expect_mapequal(list(a=1)[0], list(a=1)[0]))
+  expect_success(expect_mapequal(list(), list(a=1)[0]))
+  expect_success(expect_mapequal(list(a=1)[0], list()))
+  expect_success(expect_mapequal(list(), list()))
+  expect_success(expect_mapequal(numeric(), c(a=1)[0]))
 })

--- a/tests/testthat/test-expect-setequal.R
+++ b/tests/testthat/test-expect-setequal.R
@@ -29,10 +29,10 @@ test_that("ignores order", {
   expect_success(expect_mapequal(list(a = 1, b = 2), list(b = 2, a = 1)))
 })
 
-test_that("fails if any names are duplicated", {
-  expect_failure(expect_mapequal(list(a = 1, b = 2, b = 3), list(b = 2, a = 1)))
-  expect_failure(expect_mapequal(list(a = 1, b = 2), list(b = 3, b = 2, a = 1)))
-  expect_failure(expect_mapequal(list(a = 1, b = 2, b = 3), list(b = 3, b = 2, a = 1)))
+test_that("error if any names are duplicated", {
+  expect_error(expect_mapequal(list(a = 1, b = 2, b = 3), list(b = 2, a = 1)))
+  expect_error(expect_mapequal(list(a = 1, b = 2), list(b = 3, b = 2, a = 1)))
+  expect_error(expect_mapequal(list(a = 1, b = 2, b = 3), list(b = 3, b = 2, a = 1)))
 })
 
 test_that("handling NULLs", {
@@ -53,9 +53,9 @@ test_that("error for non-vectors", {
   expect_error(expect_mapequal(NULL, NULL), "be vectors")
 })
 
-test_that("fails if any unnamed values", {
-  expect_failure(expect_mapequal(list(1, b = 2), list(1, b = 2)))
-  expect_failure(expect_mapequal(list(1, b = 2), list(b = 2, 1)))
+test_that("error if any unnamed values", {
+  expect_error(expect_mapequal(list(1, b = 2), list(1, b = 2)))
+  expect_error(expect_mapequal(list(1, b = 2), list(b = 2, 1)))
 })
 
 test_that("succeeds if comparing empty named and unnamed vectors", {


### PR DESCRIPTION
This fixes a few things in `expect_mapequal`. It now:

* Fails if there are any duplicated names.
* Fails if there are any unnamed values.
* Succeeds when comparing any length-0 vectors, whether they are named or unnamed.