### PR TITLE
Unify as.data.frame structure for empty testthat_results

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # testthat (development version)
 
+* `as.data.frame.testthat_results()` now returns a data frame with 13 columns with predefined names, even if the input object is of length 0 (@jozefhajnala, #887).
+
 * `expect_known_value()` gains a new serialisation `version` argument,
   defaulting to 2. Prevents the `.rds` files created to hold reference objects
   from making a package appear to require R >= 3.5 (#888 @jennybc).

--- a/R/reporter-list.R
+++ b/R/reporter-list.R
@@ -95,7 +95,16 @@ any_warnings <- function(res) {
 #' @export
 as.data.frame.testthat_results <- function(x, ...) {
   if (length(x) == 0) {
-    return(data.frame())
+    return(
+      data.frame(
+        file = character(0), context = character(0), test = character(0),
+        nb = integer(0), failed = integer(0), skipped = logical(0),
+        error = logical(0), warning = integer(0),
+        user = numeric(0), system = numeric(0), real = numeric(0),
+        passed = integer(0), result = list(),
+        stringsAsFactors = FALSE
+      )
+    )
   }
 
   rows <- lapply(x, summarize_one_test_results)


### PR DESCRIPTION
This PR proposes to unify the "return type" of `as.data.frame.testthat_results()` to a data frame with 13 columns with predefined names, regardless of whether the input object is of length 0.

**Context and motivation**

I often use testthat results in a CI context, where combining (i.e. rbinding) the results of tests for multiple packages into 1 data frame is quite useful. It happens sometimes that one of those objects is empty, in which case `as.data.frame(testResults)` returns a `0 x 0` data frame, requiring further manipulation if we want to apply unified methods. 