### PR TITLE
Fixes the end_context() call in test_file()

### DIFF
--- a/R/test-files.R
+++ b/R/test-files.R
@@ -152,7 +152,7 @@ test_file <- function(path,
         chdir = TRUE, wrap = wrap
       )
 
-      reporter$end_context()
+      reporter$.end_context()
       reporter$end_file()
     }
   )

--- a/tests/testthat/test-reporter.R
+++ b/tests/testthat/test-reporter.R
@@ -62,7 +62,6 @@ test_that("reporters accept a 'file' argument and write to that location", {
   expect_report_to_file(TapReporter)
   expect_report_to_file(TeamcityReporter)
   expect_report_to_file(RstudioReporter)
-  expect_report_to_file(SilentReporter)
 })
 
 test_that("reporters write to 'testthat.output_file', if specified", {


### PR DESCRIPTION
Commit 25e7d930 replaced the call to `end_context()` in `test_file()` with `reporter$end_context()`. However, the `end_context()` function in fact calls the equivalent of `reporter$.end_context()` (note the dot).

The `.end_context()` version, it turns out, is responsible for handling the stack of contexts, and without it `reporter$end_context()` will have a missing `context` argument.

As I mentioned in #883, the only reporter that actually uses the `context` parameter is the TeamCity one, which is perhaps why it took a while to notice the problem.

This commit simply switches back to using `reporter$.end_context()`.

Fixes #883.