### PR TITLE
fixes autotest when helpers change (solve #376 and #896)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
   `auto_test_package()` automatically reloads the updated package environment
   and reruns all test, as is always the case when you modify a `test-*.R`
   file (@CorradoLanera, #376, #896).
+  
 * `expect_s3_class()` gains new `expect` argument that allows you to check
   for an exact class match, not just inheritance (#885).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # testthat (development version)
 
+* `auto_test_package()` now handles files `helper-*.R` stored into the
+  `tests/testthat/` folder. Whenever you save changes in a file `helper-*.R`,
+  `auto_test_package()` automatically reloads the updated package environment
+  and reruns all test, as is always the case when you modify a `test-*.R`
+  file (@CorradoLanera, #376, #896).
+
 # testthat 2.1.1
 
 * Fix test failures in strict latin1 locale

--- a/R/auto-test.R
+++ b/R/auto-test.R
@@ -103,21 +103,16 @@ auto_test_package <- function(pkg = ".", reporter = default_reporter(), hash = T
 
     tests <- changed[starts_with(changed, test_path)]
     helper <- tests[starts_with(basename(tests), "helper-")]
-    tests <- setdiff(tests, helper)
     code <- changed[starts_with(changed, code_path)]
+
+    # Remove helper from test and add it to code (if a helper changed,
+    # like for code, reload all and rerun all tests)
+    tests <- setdiff(tests, helper)
+    code <- c(code, helper)
 
     if (length(code) > 0) {
       # Reload code and rerun all tests
       cat("Changed code: ", paste0(basename(code), collapse = ", "), "\n")
-      cat("Rerunning all tests\n")
-      env <<- devtools::load_all(pkg, quiet = TRUE)$env
-      withr::with_envvar(
-        devtools::r_env_vars(),
-        test_dir(test_path, env = env, reporter = reporter$clone(deep = TRUE))
-      )
-    } else if (length(helper) > 0) {
-      # Reload code and rerun all tests
-      cat("Changed helper: ", paste0(basename(helper), collapse = ", "), "\n")
       cat("Rerunning all tests\n")
       env <<- devtools::load_all(pkg, quiet = TRUE)$env
       withr::with_envvar(

--- a/R/auto-test.R
+++ b/R/auto-test.R
@@ -102,11 +102,11 @@ auto_test_package <- function(pkg = ".", reporter = default_reporter(), hash = T
     changed <- normalizePath(c(added, modified))
 
     tests <- changed[starts_with(changed, test_path)]
-    helper <- tests[starts_with(basename(tests), "helper-")]
     code <- changed[starts_with(changed, code_path)]
 
     # Remove helper from test and add it to code (if a helper changed,
     # like for code, reload all and rerun all tests)
+    helper <- tests[starts_with(basename(tests), "helper-")]
     tests <- setdiff(tests, helper)
     code <- c(code, helper)
 

--- a/R/auto-test.R
+++ b/R/auto-test.R
@@ -102,11 +102,22 @@ auto_test_package <- function(pkg = ".", reporter = default_reporter(), hash = T
     changed <- normalizePath(c(added, modified))
 
     tests <- changed[starts_with(changed, test_path)]
+    helper <- tests[starts_with(basename(tests), "helper-")]
+    tests <- setdiff(tests, helper)
     code <- changed[starts_with(changed, code_path)]
 
     if (length(code) > 0) {
       # Reload code and rerun all tests
       cat("Changed code: ", paste0(basename(code), collapse = ", "), "\n")
+      cat("Rerunning all tests\n")
+      env <<- devtools::load_all(pkg, quiet = TRUE)$env
+      withr::with_envvar(
+        devtools::r_env_vars(),
+        test_dir(test_path, env = env, reporter = reporter$clone(deep = TRUE))
+      )
+    } else if (length(helper) > 0) {
+      # Reload code and rerun all tests
+      cat("Changed helper: ", paste0(basename(helper), collapse = ", "), "\n")
       cat("Rerunning all tests\n")
       env <<- devtools::load_all(pkg, quiet = TRUE)$env
       withr::with_envvar(


### PR DESCRIPTION
I separated the cases when changes in test folder come from files starting with "helper-" and replicate the same behavior and code-structure used for changes in the code folder (modifying the message printed accordingly).

I do not know how to automatize some test for the auto_test functions. I tried some interactive test (like the one described in #896) and it works fine.