### PR TITLE
Make serialization version 2 the default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
     - Rscript -e 'remotes::install_github("r-lib/vctrs")'
     env: vctrs='github'
   - r: oldrel
+  - r: 3.4
   - r: 3.3
   - r: 3.2
   - name: Strict Latin-1 locale

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # testthat (development version)
 
+* `expect_known_value()` gains a new serialisation `version` argument,
+  defaulting to 2. Prevents the `.rds` files created to hold reference objects
+  from making a package appear to require R >= 3.5 (#888 @jennybc).
+
 # testthat 2.1.1
 
 * Fix test failures in strict latin1 locale

--- a/R/expect-known.R
+++ b/R/expect-known.R
@@ -21,6 +21,9 @@
 #' @param update Should the file be updated? Defaults to `TRUE`, with
 #'   the expectation that you'll notice changes because of the first failure,
 #'   and then see the modified files in git.
+#' @param version The serialization format version to use. The default, 2, was
+#'   the default format from R 1.4.0 to 3.5.3. Version 3 became the default from
+#'   R 3.6.0 and can only be read by R versions 3.5.0 and higher.
 #' @inheritParams expect_equal
 #' @inheritParams capture_output_lines
 #' @examples
@@ -90,18 +93,19 @@ expect_known_value <- function(object, file,
                                update = TRUE,
                                ...,
                                info = NULL,
-                               label = NULL) {
+                               label = NULL,
+                               version = 2) {
   act <- quasi_label(enquo(object), label, arg = "object")
 
   if (!file.exists(file)) {
     warning("Creating reference value", call. = FALSE)
-    saveRDS(object, file)
+    saveRDS(object, file, version = version)
     succeed()
   } else {
     ref_val <- readRDS(file)
     comp <- compare(act$val, ref_val, ...)
     if (update && !comp$equal) {
-      saveRDS(act$val, file)
+      saveRDS(act$val, file, version = version)
     }
 
 

--- a/man/expect_known_output.Rd
+++ b/man/expect_known_output.Rd
@@ -12,7 +12,7 @@ expect_known_output(object, file, update = TRUE, ..., info = NULL,
   label = NULL, print = FALSE, width = 80)
 
 expect_known_value(object, file, update = TRUE, ..., info = NULL,
-  label = NULL)
+  label = NULL, version = 2)
 
 expect_known_hash(object, hash = NULL)
 }
@@ -47,6 +47,10 @@ the object is included in the overall output}
 \item{width}{Number of characters per line of output. This does not
 inherit from \code{getOption("width")} so that tests always use the same
 output width, minimising spurious differences.}
+
+\item{version}{The serialization format version to use. The default, 2, was
+the default format from R 1.4.0 to 3.5.3. Version 3 became the default from
+R 3.6.0 and can only be read by R versions 3.5.0 and higher.}
 
 \item{hash}{Known hash value. Leave empty and you'll be informed what
 to use in the test output.}

--- a/tests/testthat/test-expect-known-value.R
+++ b/tests/testthat/test-expect-known-value.R
@@ -33,3 +33,15 @@ test_that("equal_to_ref does not overwrite existing", {
   expect_failure(expect_equal_to_reference(ref_obj2, tmp_rds, update=TRUE))
   expect_success(expect_equal_to_reference(ref_obj2, tmp_rds))
 })
+
+test_that("serializes to version 2 by default", {
+  tmp_rds <- tempfile(fileext = ".rds")
+  on.exit(unlink(tmp_rds))
+
+  expect_warning(
+    expect_known_value("a", tmp_rds),
+    "Creating reference"
+  )
+
+  expect_identical(tools:::get_serialization_version(tmp_rds)[[1]], 2L)
+})

--- a/tests/testthat/test-expect-known-value.R
+++ b/tests/testthat/test-expect-known-value.R
@@ -47,6 +47,7 @@ test_that("serializes to version 2 by default", {
 })
 
 test_that("version 3 is possible", {
+  skip_if(getRversion() < 3.5)
   tmp_rds <- tempfile(fileext = ".rds")
   on.exit(unlink(tmp_rds))
 

--- a/tests/testthat/test-expect-known-value.R
+++ b/tests/testthat/test-expect-known-value.R
@@ -45,3 +45,15 @@ test_that("serializes to version 2 by default", {
 
   expect_identical(tools:::get_serialization_version(tmp_rds)[[1]], 2L)
 })
+
+test_that("version 3 is possible", {
+  tmp_rds <- tempfile(fileext = ".rds")
+  on.exit(unlink(tmp_rds))
+
+  expect_warning(
+    expect_known_value("a", tmp_rds, version = 3),
+    "Creating reference"
+  )
+
+  expect_identical(tools:::get_serialization_version(tmp_rds)[[1]], 3L)
+})

--- a/tests/testthat/test-expect-known-value.R
+++ b/tests/testthat/test-expect-known-value.R
@@ -35,6 +35,7 @@ test_that("equal_to_ref does not overwrite existing", {
 })
 
 test_that("serializes to version 2 by default", {
+  skip_if(getRversion() < 3.5)
   tmp_rds <- tempfile(fileext = ".rds")
   on.exit(unlink(tmp_rds))
 


### PR DESCRIPTION
Closes #888

Also adds 3.4 to the build matrix, which had fallen through the cracks, with the release of 3.6.