### PR TITLE
Improve summary report readability

### DIFF
--- a/R/reporter-check.R
+++ b/R/reporter-check.R
@@ -48,10 +48,12 @@ CheckReporter <- R6::R6Class("CheckReporter",
     end_reporter = function() {
       self$rule("testthat results ", line = 2)
       self$cat_line(
-        "OK: ", self$n_ok, " ",
-        "SKIPPED: ", self$n_skip, " ",
-        "WARNINGS: ", self$n_warn, " ",
-        "FAILED: ", self$n_fail
+        "[ ",
+        "OK: ", self$n_ok, " | ",
+        "SKIPPED: ", self$n_skip, " | ",
+        "WARNINGS: ", self$n_warn, " | ",
+        "FAILED: ", self$n_fail,
+        " ]"
       )
 
       if (self$n_fail == 0) return()

--- a/tests/testthat/reporters/check.txt
+++ b/tests/testthat/reporters/check.txt
@@ -48,7 +48,7 @@ This is deep
 27: stop("This is deep") at reporters/tests.R:54
 
 ══ testthat results  ═══════════════════════════════════════════════════════════
-OK: 5 SKIPPED: 3 WARNINGS: 3 FAILED: 7
+[ OK: 5 | SKIPPED: 3 | WARNINGS: 3 | FAILED: 7 ]
 1. Failure: Failure:1 (@tests.R#12) 
 2. Failure: Failure:2a (@tests.R#16) 
 3. Failure: Failure:2b (@tests.R#19) 


### PR DESCRIPTION
Closes #891 

This PR improves the readability of the summary report output by adding separators between check status types.

Specifically we have gone from:

`OK: 5 SKIPPED: 3 WARNINGS: 3 FAILED: 7`

to

`[ OK: 5 | SKIPPED: 3 | WARNINGS: 3 | FAILED: 7 ]`