### PR TITLE
Abort when `Stop` reporter encounters a failure

### DIFF
--- a/R/expectation.R
+++ b/R/expectation.R
@@ -220,3 +220,12 @@ single_letter_summary <- function(x) {
     "?"
   )
 }
+
+exp_location <- function(exp) {
+  if (is.null(exp$srcref)) {
+    "???"
+  } else {
+    filename <- attr(exp$srcref, "srcfile")$filename
+    paste0(basename(filename), ":", exp$srcref[1])
+  }
+}

--- a/R/reporter-stop.R
+++ b/R/reporter-stop.R
@@ -33,9 +33,15 @@ StopReporter <- R6::R6Class("StopReporter",
       self$failures$initialize()
 
       messages <- vapply(failures, format, character(1))
-      messages <- paste0("* ", messages, collapse = "\n")
+      locations <- vapply(failures, exp_location, character(1))
+      messages <- paste0("* ", locations, ": ", messages, collapse = "\n")
+      message <- paste_line(
+        paste0("Test failed: '", test, "'"),
+        !!!messages
+      )
 
-      stop("Test failed: '", test, "'\n", messages, call. = FALSE)
+      cat(message, "\n", file = stderr())
+      invokeRestart("abort")
     },
 
     add_result = function(context, test, result) {

--- a/R/reporter-stop.R
+++ b/R/reporter-stop.R
@@ -40,8 +40,8 @@ StopReporter <- R6::R6Class("StopReporter",
         !!!messages
       )
 
-      cat(message, "\n", file = stderr())
-      invokeRestart("abort")
+      cat(message, "\n")
+      invokeRestart("testthat_abort_reporter")
     },
 
     add_result = function(context, test, result) {

--- a/R/reporter-zzz.R
+++ b/R/reporter-zzz.R
@@ -55,7 +55,10 @@ with_reporter <- function(reporter, code, start_end_reporter = TRUE) {
     reporter$start_reporter()
   }
 
-  force(code)
+  withRestarts(
+    testthat_abort_reporter = function() NULL,
+    force(code)
+  )
 
   if (start_end_reporter) {
     reporter$end_reporter()

--- a/tests/testthat/reporters/fail.R
+++ b/tests/testthat/reporters/fail.R
@@ -1,0 +1,10 @@
+context("fail")
+
+test_that("two failures", {
+  expect_true(FALSE)
+  expect_false(TRUE)
+})
+
+test_that("another failure", {
+  expect_true(FALSE)
+})

--- a/tests/testthat/reporters/stop.txt
+++ b/tests/testthat/reporters/stop.txt
@@ -1,0 +1,3 @@
+Test failed: 'two failures'
+* fail.R:4: FALSE isn't true.
+* fail.R:5: TRUE isn't false. 

--- a/tests/testthat/test-reporter.R
+++ b/tests/testthat/test-reporter.R
@@ -69,3 +69,7 @@ test_that("reporters write to 'testthat.output_file', if specified", {
 test_that("backtraces are reported", {
   expect_report_unchanged("progress-backtraces", file = "reporters/backtraces.R", ProgressReporter$new(show_praise = FALSE, min_time = Inf, update_interval = 0))
 })
+
+test_that("stop reporter stops at first failure", {
+  expect_report_unchanged("stop", find_reporter("stop"), file = "reporters/fail.R")
+})


### PR DESCRIPTION
Closes #851

* Adds srcref to bullet list so location of failures can be traced.
* Invokes abort restart to shut down testthat.

```r
testthat::test_file("tests/testthat/test_dir/test-failures.R", reporter = "stop")
#> Test failed: 'just one failure'
#> * test-failures.R:4: FALSE isn't true. 
```