### PR TITLE
Call `conditionMessage()` in condition expectations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 
 # testthat (development version)
 
+* `expect_error()`, `expect_warning()` and `expect_message()` now call
+  `conditionMessage()` to get the condition message. This generic
+  makes it possible to generate messages at print-time rather than
+  signal-time.
 
 * JunitReporter now reports tests in ISO 8601 in the UTC timezone and also uses
   the maximum 3 decimal place precision (#923).

--- a/R/capture-condition.R
+++ b/R/capture-condition.R
@@ -105,5 +105,5 @@ capture_warnings <- function(code) {
 }
 
 get_messages <- function(x) {
-  vapply(x, "[[", "message", FUN.VALUE = character(1))
+  vapply(x, cnd_message, FUN.VALUE = character(1))
 }

--- a/R/expect-output.R
+++ b/R/expect-output.R
@@ -230,7 +230,7 @@ compare_condition <- function(cond, lab, regexp = NULL, class = NULL, ...,
         "%s threw an %s.\nMessage: %s\nClass:   %s",
         lab,
         cond_type,
-        conditionMessage(cond),
+        cnd_message(cond),
         paste(class(cond), collapse = "/")
       ))
     } else {
@@ -243,7 +243,7 @@ compare_condition <- function(cond, lab, regexp = NULL, class = NULL, ...,
     return(sprintf("%s did not throw an %s.", lab, cond_type))
   }
 
-  message <- conditionMessage(cond)
+  message <- cnd_message(cond)
 
   ok_class <- is.null(class) || inherits(cond, class)
   ok_msg <- is.null(regexp) || grepl(regexp, message, ...)
@@ -280,6 +280,13 @@ compare_condition <- function(cond, lab, regexp = NULL, class = NULL, ...,
     paste(problems, collapse = " and "),
     paste(details, collapse = "\n")
   )
+}
+
+# Disable rlang backtrace reminders so they don't interfere with
+# expected error messages
+cnd_message <- function(x) {
+  withr::local_options(c(rlang_backtrace_on_error = "none"))
+  conditionMessage(x)
 }
 
 simple_error <- function(x) {

--- a/R/expect-output.R
+++ b/R/expect-output.R
@@ -230,7 +230,7 @@ compare_condition <- function(cond, lab, regexp = NULL, class = NULL, ...,
         "%s threw an %s.\nMessage: %s\nClass:   %s",
         lab,
         cond_type,
-        cond$message,
+        conditionMessage(cond),
         paste(class(cond), collapse = "/")
       ))
     } else {
@@ -243,8 +243,10 @@ compare_condition <- function(cond, lab, regexp = NULL, class = NULL, ...,
     return(sprintf("%s did not throw an %s.", lab, cond_type))
   }
 
+  message <- conditionMessage(cond)
+
   ok_class <- is.null(class) || inherits(cond, class)
-  ok_msg <- is.null(regexp) || grepl(regexp, cond$message, ...)
+  ok_msg <- is.null(regexp) || grepl(regexp, message, ...)
 
   # All good
   if (ok_msg && ok_class) {
@@ -259,14 +261,14 @@ compare_condition <- function(cond, lab, regexp = NULL, class = NULL, ...,
         "Expected class: %s\nActual class:   %s\nMessage:        %s",
         paste0(class, collapse = "/"),
         paste0(class(cond), collapse = "/"),
-        cond$message
+        message
       )
     },
     if (!ok_msg) {
       sprintf(
         "Expected match: %s\nActual message: %s",
         encodeString(regexp, quote = '"'),
-        encodeString(cond$message, quote = '"')
+        encodeString(message, quote = '"')
       )
     }
   )

--- a/tests/testthat/test-expect-error.R
+++ b/tests/testthat/test-expect-error.R
@@ -67,3 +67,33 @@ test_that("warnings are converted to errors when options('warn') >= 2", {
     expect_error(warning("foo"))
   )
 })
+
+local({
+  # Define method in the global environment so it's consistently reached
+  scoped_bindings(
+    conditionMessage.foobar = function(err) "dispatched!",
+    .env = global_env()
+  )
+  foobar <- error_cnd("foobar")
+
+  test_that("message method is called when expecting error", {
+    expect_error(stop(foobar), "dispatched!", class = "foobar")
+  })
+
+  test_that("message method is called with unexpected message", {
+    expect_error(
+      expect_error(stop(foobar), "unexpected", class = "foobar"),
+      "Actual message: \"dispatched!\"",
+      fixed = TRUE,
+      class = "expectation_failure"
+    )
+  })
+
+  test_that("message method is called with unexpected error", {
+    expect_error(
+      expect_error(stop(foobar), NA, class = "foobar"),
+      "dispatched!",
+      class = "expectation_failure"
+    )
+  })
+})

--- a/tests/testthat/test-expect-error.R
+++ b/tests/testthat/test-expect-error.R
@@ -97,3 +97,10 @@ local({
     )
   })
 })
+
+test_that("rlang backtrace reminders are not included in error message", {
+  f <- function() g()
+  g <- function() h()
+  h <- function() abort("foo")
+  expect_error(f(), "foo$")
+})

--- a/tests/testthat/test-expect-error.R
+++ b/tests/testthat/test-expect-error.R
@@ -96,6 +96,16 @@ local({
       class = "expectation_failure"
     )
   })
+
+  test_that("message method is called with expected warnings", {
+    foobar <- warning_cnd("foobar")
+    expect_warning(warning(foobar), "dispatched!")
+  })
+
+  test_that("message method is called with expected messages", {
+    foobar <- message_cnd("foobar")
+    expect_message(message(foobar), "dispatched!")
+  })
 })
 
 test_that("rlang backtrace reminders are not included in error message", {


### PR DESCRIPTION
I'd like to switch to print-time generation of error messages with the `conditionMessage()` generic. This should improve performance of the error path (which might be recovered with a restart or a try-catch) when the error message is expensive to generate (typically when it needs to examine data to provide context about faulty inputs).

With this PR the condition expectations in testthat now call `conditionMessage()` instead of looking into the `message` field.