### PR TITLE
Add `unicode` parameter to `verify_output()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,11 @@
 
 * `verify_output()` no longer uses quasiquotation, which fixes issues
   when verifying the output of tidy eval functions (#945).
+* `verify_output()` gains a `unicode` parameter to turn on or off the
+  use of Unicode characters by the cli package. It is disabled by
+  default to prevent the tests from failing on platforms like Windows
+  that don't support UTF-8 (which could be your contributors or your
+  CI machines).
 
 * `verify_output()` now correctly handles multi-line condition
   messages.

--- a/R/verify-output.R
+++ b/R/verify-output.R
@@ -24,9 +24,13 @@
 #' @param code Code to execute.
 #' @param width Width of console output
 #' @param crayon Enable crayon package colouring?
+#' @param unicode Enable cli package UTF-8 symbols? If you set this to
+#'   `TRUE`, call `skip_if(!cli::is_utf8_output())` to disable the
+#'   test on your CI platforms that don't support UTF-8 (e.g. Windows).
 #' @param env The environment to evaluate `code` in.
 #' @export
-verify_output <- function(path, code, width = 80, crayon = FALSE, env = caller_env()) {
+verify_output <- function(path, code, width = 80, crayon = FALSE,
+                          unicode = FALSE, env = caller_env()) {
   expr <- substitute(code)
 
   if (is_call(expr, "{")) {
@@ -35,7 +39,11 @@ verify_output <- function(path, code, width = 80, crayon = FALSE, env = caller_e
     exprs <- list(expr)
   }
 
-  withr::local_options(list(width = width, crayon.enabled = crayon))
+  withr::local_options(list(
+    width = width,
+    crayon.enabled = crayon,
+    cli.unicode = unicode
+  ))
   withr::local_envvar(list(RSTUDIO_CONSOLE_WIDTH = width))
 
   exprs <- lapply(exprs, function(x) if (is.character(x)) paste0("# ", x) else expr_deparse(x))

--- a/man/verify_output.Rd
+++ b/man/verify_output.Rd
@@ -5,7 +5,7 @@
 \title{Verify output}
 \usage{
 verify_output(path, code, width = 80, crayon = FALSE,
-  env = caller_env())
+  unicode = FALSE, env = caller_env())
 }
 \arguments{
 \item{path}{Path to save file. Typically this will be a call to
@@ -16,6 +16,10 @@ verify_output(path, code, width = 80, crayon = FALSE,
 \item{width}{Width of console output}
 
 \item{crayon}{Enable crayon package colouring?}
+
+\item{unicode}{Enable cli package UTF-8 symbols? If you set this to
+\code{TRUE}, call \code{skip_if(!cli::is_utf8_output())} to disable the
+test on your CI platforms that don't support UTF-8 (e.g. Windows).}
 
 \item{env}{The environment to evaluate \code{code} in.}
 }

--- a/tests/testthat/test-verify-output.R
+++ b/tests/testthat/test-verify-output.R
@@ -56,3 +56,20 @@ test_that("can use constructed calls in verify_output() (#945)", {
     expr(foo(!!binding))
   })
 })
+
+test_that("verify_output() doesn't use cli unicode by default", {
+  verify_output(
+    test_path("test-verify-unicode-false.txt"),
+    {
+      cat(cli::symbol$info, cli::symbol$cross, "\n")
+    }
+  )
+
+  skip_if(!cli::is_utf8_output())
+  verify_output(
+    test_path("test-verify-unicode-true.txt"),
+    unicode = TRUE,
+    {
+      cat(cli::symbol$info, cli::symbol$cross, "\n")
+    })
+})

--- a/tests/testthat/test-verify-unicode-false.txt
+++ b/tests/testthat/test-verify-unicode-false.txt
@@ -1,0 +1,3 @@
+> cat(cli::symbol$info, cli::symbol$cross, "\n")
+i x 
+

--- a/tests/testthat/test-verify-unicode-true.txt
+++ b/tests/testthat/test-verify-unicode-true.txt
@@ -1,0 +1,3 @@
+> cat(cli::symbol$info, cli::symbol$cross, "\n")
+ℹ ✖ 
+


### PR DESCRIPTION
Disabled by default to avoid failures on Windows CI.