### PR TITLE
Export reassign_function C code and provide a header file

### DIFF
--- a/inst/include/testthatAPI.h
+++ b/inst/include/testthatAPI.h
@@ -1,0 +1,17 @@
+#include <R_ext/Rdynload.h>
+#include <R.h>
+#include <Rinternals.h>
+
+SEXP duplicate_(SEXP x) {
+  static SEXP(*fun)(SEXP) = NULL;
+  if (fun == NULL)
+    fun = (SEXP(*)(SEXP)) R_GetCCallable("testthat", "duplicate_");
+  return fun(x);
+}
+
+SEXP reassign_function(SEXP name, SEXP env, SEXP old_fun, SEXP new_fun) {
+  static SEXP(*fun)(SEXP, SEXP, SEXP, SEXP) = NULL;
+  if (fun == NULL)
+    fun = (SEXP(*)(SEXP, SEXP, SEXP, SEXP)) R_GetCCallable("testthat", "reassign_function");
+  return fun(name, nev, old_fun, new_fun);
+}

--- a/inst/include/testthatAPI.h
+++ b/inst/include/testthatAPI.h
@@ -13,5 +13,5 @@ SEXP reassign_function(SEXP name, SEXP env, SEXP old_fun, SEXP new_fun) {
   static SEXP(*fun)(SEXP, SEXP, SEXP, SEXP) = NULL;
   if (fun == NULL)
     fun = (SEXP(*)(SEXP, SEXP, SEXP, SEXP)) R_GetCCallable("testthat", "reassign_function");
-  return fun(name, nev, old_fun, new_fun);
+  return fun(name, env, old_fun, new_fun);
 }

--- a/src/init.c
+++ b/src/init.c
@@ -17,6 +17,8 @@ static const R_CallMethodDef CallEntries[] = {
 
 void R_init_testthat(DllInfo *dll)
 {
+    R_RegisterCCallable("testthat", "duplicate_",  (DL_FUNC) &duplicate_);
+    R_RegisterCCallable("testthat", "reassign_function",  (DL_FUNC) &reassign_function);
     R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
     R_useDynamicSymbols(dll, FALSE);
 }


### PR DESCRIPTION
First of all, thanks for all of the work that has gone in to `testthat` 

Would it be possible to export and provide a header file for `reassign_function` and `duplicate_` for use in other packages? I'm working on a [database testing package](https://github.com/jonkeane/dittodb) that would benefit from importing them directly rather than copying the code over.

I've made the necessary changes in this PR following [R packages](http://r-pkgs.had.co.nz/src.html#c-export) but am happy to make any adjustments or additions requested.