### PR TITLE
Use pdf() device instead of png()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # testthat (development version)
 
+* `verify_output()` now uses the `pdf()` device instead of `png()`; that makes
+  it work on systems without X11 (#1011).
+
 * `expect_identical()`, `expect_equal()`, `expect_equivalent()` and
   `verify_output()` now use `waldo::compare()` to compare actual and expected
   results. The chief difference should be that you now get much more 

--- a/R/verify-output.R
+++ b/R/verify-output.R
@@ -117,7 +117,7 @@ verify_exec <- function(exprs,
   source <- unlist(exprs, recursive = FALSE)
 
   # Open temporary new device
-  grDevices::png(filename = tempfile())
+  grDevices::pdf(tempfile())
   grDevices::dev.control(displaylist = "enable")
   dev <- grDevices::dev.cur()
   on.exit(grDevices::dev.off(dev), add = TRUE)

--- a/R/verify-output.R
+++ b/R/verify-output.R
@@ -103,6 +103,9 @@ verify_exec <- function(exprs,
                         unicode = FALSE,
                         env = caller_env()) {
 
+  exprs <- lapply(exprs, function(x) if (is.character(x)) paste0("# ", x) else expr_deparse(x))
+  source <- unlist(exprs, recursive = FALSE)
+
   withr::local_options(list(
     width = width,
     crayon.enabled = crayon,
@@ -112,15 +115,8 @@ verify_exec <- function(exprs,
     RSTUDIO = 0,
     RSTUDIO_CONSOLE_WIDTH = width
   ))
-
-  exprs <- lapply(exprs, function(x) if (is.character(x)) paste0("# ", x) else expr_deparse(x))
-  source <- unlist(exprs, recursive = FALSE)
-
-  # Open temporary new device
-  grDevices::pdf(tempfile())
+  withr::local_pdf(tempfile())
   grDevices::dev.control(displaylist = "enable")
-  dev <- grDevices::dev.cur()
-  on.exit(grDevices::dev.off(dev), add = TRUE)
 
   results <- evaluate::evaluate(source, envir = env, new_device = FALSE)
   unlist(lapply(results, output_replay))


### PR DESCRIPTION
I experimented with getting rid of the device all together, but I couldn't get it to work, likely because of the hoops that evaluate jumps through to capture graphics device state. I think pdf() should work everywhere.

Fixes #1011