### PR TITLE
Check class in expect_messages() and expect_warnings()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # testthat (development version)
 
+* `expect_message()` and `expect_warning()` gain a `class` argument so that you
+  can assert that message or warnings have a specific class, rather than
+  checking for matching text (#1052).
+
+* `expect_message()`, `expect_warning()`, `expect_error()`, and 
+  `expect_condition()` all warn if you supply additional arguments that aren't
+  actually used.
+
 * `ProgressReport` (the default reporter) now keeps the stack traces of
   an errors that happen before the before test, making problems substantially
   easier to track down (#1004).

--- a/R/capture-condition.R
+++ b/R/capture-condition.R
@@ -76,23 +76,28 @@ capture_warning <- new_capture("warning")
 
 #' @export
 #' @rdname capture_condition
-capture_messages <- function(code) {
+capture_messages <- function(code, message_only = TRUE) {
   out <- Stack$new()
 
   withCallingHandlers(
     code,
-    message = function(condition) {
-      out$push(condition)
+    message = function(cnd) {
+      out$push(cnd)
+      cnd_muffle(cnd)
       maybe_restart("muffleMessage")
     }
   )
 
-  get_messages(out$as_list())
+  if (message_only) {
+    get_messages(out$as_list())
+  } else {
+    out$as_list()
+  }
 }
 
 #' @export
 #' @rdname capture_condition
-capture_warnings <- function(code) {
+capture_warnings <- function(code, message_only = TRUE) {
   out <- Stack$new()
 
   withCallingHandlers(
@@ -103,7 +108,12 @@ capture_warnings <- function(code) {
     }
   )
 
-  get_messages(out$as_list())
+  if (message_only) {
+    get_messages(out$as_list())
+  } else {
+    out$as_list()
+  }
+
 }
 
 get_messages <- function(x) {

--- a/R/expect-condition.R
+++ b/R/expect-condition.R
@@ -65,6 +65,8 @@ expect_error <- function(object,
                          info = NULL,
                          label = NULL
                          ) {
+  ellipsis::check_dots_used(action = warn)
+
   act <- quasi_capture(enquo(object), label, capture_error, entrace = TRUE)
   msg <- compare_condition(act$cap, act$lab, regexp = regexp, class = class, ...)
 
@@ -96,6 +98,8 @@ expect_condition <- function(object,
                              info = NULL,
                              label = NULL
                              ) {
+  ellipsis::check_dots_used(action = warn)
+
   act <- quasi_capture(enquo(object), label, capture_condition, entrace = TRUE)
   msg <- compare_condition(
     act$cap, act$lab, regexp = regexp, class = class, ...,

--- a/R/expect-condition.R
+++ b/R/expect-condition.R
@@ -68,7 +68,10 @@ expect_error <- function(object,
   ellipsis::check_dots_used(action = warn)
 
   act <- quasi_capture(enquo(object), label, capture_error, entrace = TRUE)
-  msg <- compare_condition(act$cap, act$lab, regexp = regexp, class = class, ...)
+  msg <- compare_condition(
+    act$cap, act$lab, regexp = regexp, class = class, ...,
+    cond_type = "an error"
+  )
 
   # Access error fields with `[[` rather than `$` because the
   # `$.Throwable` from the rJava package throws with unknown fields
@@ -103,7 +106,7 @@ expect_condition <- function(object,
   act <- quasi_capture(enquo(object), label, capture_condition, entrace = TRUE)
   msg <- compare_condition(
     act$cap, act$lab, regexp = regexp, class = class, ...,
-    cond_type = "condition"
+    cond_type = "a condition"
   )
   expect(is.null(msg), msg, info = info, trace = act$cap[["trace"]])
 
@@ -113,13 +116,13 @@ expect_condition <- function(object,
 # Helpers -----------------------------------------------------------------
 
 compare_condition <- function(cond, lab, regexp = NULL, class = NULL, ...,
-                              cond_type = "error") {
+                              cond_type = "a condition") {
 
   # Expecting no condition
   if (identical(regexp, NA)) {
     if (!is.null(cond)) {
       return(sprintf(
-        "%s threw an %s.\nMessage: %s\nClass:   %s",
+        "%s threw %s.\nMessage: %s\nClass:   %s",
         lab,
         cond_type,
         cnd_message(cond),
@@ -132,7 +135,7 @@ compare_condition <- function(cond, lab, regexp = NULL, class = NULL, ...,
 
   # Otherwise we're definitely expecting a condition
   if (is.null(cond)) {
-    return(sprintf("%s did not throw an %s.", lab, cond_type))
+    return(sprintf("%s did not throw %s.", lab, cond_type))
   }
 
   message <- cnd_message(cond)
@@ -166,7 +169,7 @@ compare_condition <- function(cond, lab, regexp = NULL, class = NULL, ...,
   )
 
   sprintf(
-    "%s threw an %s with unexpected %s.\n%s",
+    "%s threw %s with unexpected %s.\n%s",
     lab,
     cond_type,
     paste(problems, collapse = " and "),

--- a/R/expect-messages.R
+++ b/R/expect-messages.R
@@ -80,7 +80,7 @@ expect_message <- function(object,
     class = class,
     all = all,
     ...,
-    cond_type = "message"
+    cond_type = "a message"
   )
   expect(is.null(msg), msg, info = info)
 
@@ -106,7 +106,7 @@ expect_warning <- function(object,
     class = class,
     all = all,
     ...,
-    cond_type = "warning"
+    cond_type = "a warning"
   )
   expect(is.null(msg), msg, info = info)
 
@@ -128,7 +128,7 @@ compare_conditions <- function(conds, lab, regexp = NULL, class = NULL, ...,
       return()
     }
   } else if (length(conds) == 0) {
-    return(sprintf("%s did not produce a %s.", lab, cond_type))
+    return(sprintf("%s did not produce %s.", lab, cond_type))
   }
 
   comp <- lapply(conds, compare_condition,

--- a/man/capture_condition.Rd
+++ b/man/capture_condition.Rd
@@ -20,9 +20,9 @@ capture_message(code, entrace = FALSE)
 
 capture_warning(code, entrace = FALSE)
 
-capture_messages(code)
+capture_messages(code, message_only = TRUE)
 
-capture_warnings(code)
+capture_warnings(code, message_only = TRUE)
 }
 \arguments{
 \item{code}{Code to evaluate}

--- a/man/expect_message.Rd
+++ b/man/expect_message.Rd
@@ -8,6 +8,7 @@
 expect_message(
   object,
   regexp = NULL,
+  class = NULL,
   ...,
   all = FALSE,
   info = NULL,
@@ -17,6 +18,7 @@ expect_message(
 expect_warning(
   object,
   regexp = NULL,
+  class = NULL,
   ...,
   all = FALSE,
   info = NULL,
@@ -37,6 +39,10 @@ message/warning
 but doesn't test for a specific value.
 \item If \code{NA}, asserts that there shouldn't be any messages or warnings.
 }}
+
+\item{class}{Instead of supplying a regular expression, you can also supply
+a class name. This is useful for "classed" conditions. See
+discussion in \code{\link[=expect_error]{expect_error()}} for details.}
 
 \item{...}{
   Arguments passed on to \code{\link[=expect_match]{expect_match}}
@@ -59,8 +65,9 @@ alternatives in \link{quasi_label}.}
 The first argument, invisibly.
 }
 \description{
-Use \code{expect_message()} and \code{expect_warning()} to check if the messages or
-warnings match the given regular expression.
+\code{expect_message()} and \code{expect_warning()} check if \emph{any} messages or
+warning (respectively) matches the given pattern (regular expression) or
+class.
 }
 \examples{
 # Messages ------------------------------------------------------------------

--- a/tests/testthat/reporters/progress-backtraces.txt
+++ b/tests/testthat/reporters/progress-backtraces.txt
@@ -39,7 +39,7 @@ Backtrace:
  7. bar()
 
 backtraces.R:35: failure: failed expect_error() prints a backtrace
-`f()` threw an condition with unexpected class.
+`f()` threw a condition with unexpected class.
 
 Backtrace:
  1. testthat::expect_condition(f(), class = "foo")

--- a/tests/testthat/test-expect-condition.R
+++ b/tests/testthat/test-expect-condition.R
@@ -37,7 +37,7 @@ test_that("class = string matches class of error", {
   )
   expect_failure(
     expect_condition(blah(), class = "blech"),
-    "threw an condition with unexpected class"
+    "threw a condition with unexpected class"
   )
 })
 

--- a/tests/testthat/test-expect-messages-warning.txt
+++ b/tests/testthat/test-expect-messages-warning.txt
@@ -2,21 +2,21 @@
 `null()` did not produce a warning.
 
 -- 2. Failure:  (@test-expect-messages.R#98)  ----------------------------------
-`foo()` generated warning:
+`foo()` generated a warning:
 * xxx
 * yyy
 
 -- 3. Failure:  (@test-expect-messages.R#99)  ----------------------------------
-`foo()` threw an warning with unexpected message.
+`foo()` threw a warning with unexpected message.
 Expected match: "zzz"
 Actual message: "xxx"
 
-`foo()` threw an warning with unexpected message.
+`foo()` threw a warning with unexpected message.
 Expected match: "zzz"
 Actual message: "yyy"
 
 -- 4. Failure:  (@test-expect-messages.R#100)  ---------------------------------
-`foo()` threw an warning with unexpected message.
+`foo()` threw a warning with unexpected message.
 Expected match: "xxx"
 Actual message: "yyy"
 

--- a/tests/testthat/test-expect-messages-warning.txt
+++ b/tests/testthat/test-expect-messages-warning.txt
@@ -1,22 +1,22 @@
--- 1. Failure:  (@test-expect-messages.R#85)  ----------------------------------
-`null()` did not produce any warnings.
+-- 1. Failure:  (@test-expect-messages.R#97)  ----------------------------------
+`null()` did not produce a warning.
 
--- 2. Failure:  (@test-expect-messages.R#86)  ----------------------------------
-`foo()` generated warnings:
+-- 2. Failure:  (@test-expect-messages.R#98)  ----------------------------------
+`foo()` generated warning:
 * xxx
 * yyy
 
--- 3. Failure:  (@test-expect-messages.R#87)  ----------------------------------
-`foo()` produced unexpected warnings.
-Expected match: zzz
-Actual values:
-* xxx
-* yyy
+-- 3. Failure:  (@test-expect-messages.R#99)  ----------------------------------
+`foo()` threw an warning with unexpected message.
+Expected match: "zzz"
+Actual message: "xxx"
 
--- 4. Failure:  (@test-expect-messages.R#88)  ----------------------------------
-`foo()` produced unexpected warnings.
-Expected match: xxx
-Actual values:
-* xxx
-* yyy
+`foo()` threw an warning with unexpected message.
+Expected match: "zzz"
+Actual message: "yyy"
+
+-- 4. Failure:  (@test-expect-messages.R#100)  ---------------------------------
+`foo()` threw an warning with unexpected message.
+Expected match: "xxx"
+Actual message: "yyy"
 

--- a/tests/testthat/test-expect-messages.R
+++ b/tests/testthat/test-expect-messages.R
@@ -10,12 +10,18 @@ test_that("inputs evaluated in correct scope", {
 
 test_that("regexp = NULL checks for presence of message", {
   expect_success(expect_message(message("!")))
-  expect_failure(expect_message(null()), "did not produce any messages")
+  expect_failure(expect_message(null()), "did not produce a message")
 })
 
 test_that("regexp = NA checks for absence of message", {
   expect_success(expect_message(null(), NA))
   expect_failure(expect_message(message("!"), NA))
+})
+
+test_that("can check for specified class", {
+  f <- function() inform("hi", class = "message_foo")
+  expect_success(expect_message(f(), class = "message_foo"))
+  expect_failure(expect_message(f(), class = "message_bar"))
 })
 
 test_that("regexp = string matches _any_ message", {
@@ -28,7 +34,7 @@ test_that("regexp = string matches _any_ message", {
   expect_success(expect_message(f(), "a"))
   expect_success(expect_message(f(), "b"))
   expect_failure(expect_message(f(), "c"))
-  expect_failure(expect_message("", "c"), "did not produce any messages")
+  expect_failure(expect_message("", "c"), "did not produce a message")
 })
 
 test_that("... passed on to grepl", {
@@ -44,12 +50,18 @@ test_that("returns first argument", {
 
 test_that("regexp = NULL checks for presence of warning", {
   expect_success(expect_warning(warning("!")))
-  expect_failure(expect_warning(null()), "did not produce any warnings")
+  expect_failure(expect_warning(null()), "did not produce a warning")
 })
 
 test_that("regexp = NA checks for absence of warning", {
   expect_success(expect_warning(null(), NA))
   expect_failure(expect_warning(warning("!"), NA))
+})
+
+test_that("can check for specified class", {
+  f <- function() warn("hi", class = "message_foo")
+  expect_success(expect_warning(f(), class = "message_foo"))
+  expect_failure(expect_warning(f(), class = "message_bar"))
 })
 
 test_that("regexp = string matches _any_ warning", {
@@ -62,7 +74,7 @@ test_that("regexp = string matches _any_ warning", {
   expect_success(expect_warning(f(), "a"))
   expect_success(expect_warning(f(), "b"))
   expect_failure(expect_warning(f(), "c"))
-  expect_failure(expect_warning("", "c"), "did not produce any warnings")
+  expect_failure(expect_warning("", "c"), "did not produce a warning")
 })
 
 test_that("... passed on to grepl", {
@@ -76,7 +88,7 @@ test_that("returns first argument", {
 test_that("generates informative failures", {
   skip_if_not(l10n_info()$`UTF-8`)
 
-  expect_known_failure("test-expect-messages-warning.txt", {
+  expect_known_failure(test_path("test-expect-messages-warning.txt"), {
     foo <- function() {
       warning("xxx")
       warning("yyy")


### PR DESCRIPTION
This unifies the output across expect_message()/expect_warning() and expect_condition()/expect_error(). The new messages are possibly a little less informative when you have multiple messages/warnings that don't match, but I think this is relatively rare and it's a relatively small decrease in utility so I haven't put more time into fixing it.

I also added calls to ellispis::check_dots_used() to make sure other arguments aren't silently swallowed in the same way that `class` was here.

Fixes #1052