### PR TITLE
Fix parallel tests

### DIFF
--- a/R/parallel.R
+++ b/R/parallel.R
@@ -140,8 +140,12 @@ queue_setup <- function(test_paths,
 }
 
 queue_process_setup <- function(test_package, test_dir, load_helpers, load_package) {
-  env <- test_files_setup_env(test_package, test_dir, load_package)
-  test_files_setup_state(
+  env <- asNamespace("testthat")$test_files_setup_env(
+    test_package,
+    test_dir,
+    load_package
+  )
+  asNamespace("testthat")$test_files_setup_state(
     test_dir = test_dir,
     test_package = test_package,
     load_helpers = load_helpers,

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -110,7 +110,6 @@ replay_events <- function(reporter, events) {
 queue_setup <- function(test_paths,
                         test_package,
                         test_dir,
-                        env,
                         num_workers,
                         load_helpers,
                         load_package) {

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -114,6 +114,10 @@ queue_setup <- function(test_paths,
                         load_helpers,
                         load_package) {
 
+  # TODO: observe `load_package`, but the "none" default is not
+  # OK for the subprocess, because it'll not have the tested package
+  if (load_package == "none") load_package <- "source"
+
   # TODO: meaningful error if startup fails
   load_hook <- expr(asNamespace("testthat")$queue_process_setup(
     test_package = !!test_package,

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -179,10 +179,14 @@ queue_teardown <- function(queue) {
   tasks <- queue$list_tasks()
   num <- nrow(tasks)
 
+  clean_fn <- function() {
+    withr::deferred_run(.GlobalEnv)
+  }
+
   topoll <- list()
   for (i in seq_len(num)) {
     if (!is.null(tasks$worker[[i]])) {
-      tasks$worker[[i]]$call(withr::deferred_run, list(global_env))
+      tasks$worker[[i]]$call(clean_fn)
       close(tasks$worker[[i]]$get_input_connection())
       topoll <- c(topoll, tasks$worker[[i]]$get_poll_connection())
     }

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -122,6 +122,8 @@ queue_setup <- function(test_paths,
   # is not appropriate in the subprocess
   load_helpers <- TRUE
 
+  test_package <- test_package %||% Sys.getenv("TESTTHAT_PKG")
+
   # TODO: meaningful error if startup fails
   load_hook <- expr(asNamespace("testthat")$queue_process_setup(
     test_package = !!test_package,

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -118,6 +118,10 @@ queue_setup <- function(test_paths,
   # OK for the subprocess, because it'll not have the tested package
   if (load_package == "none") load_package <- "source"
 
+  # TODO: similarly, load_helpers = FALSE, coming from devtools,
+  # is not appropriate in the subprocess
+  load_helpers <- TRUE
+
   # TODO: meaningful error if startup fails
   load_hook <- expr(asNamespace("testthat")$queue_process_setup(
     test_package = !!test_package,


### PR DESCRIPTION
Please see the individual commits for details. 

Some of these changes need improvements, still:

* Helpers are now always loaded in the subprocess. We probably should have a way to observe the `load_helpers` argument. The problem is that `devtools::test()` always passes `load_helpers = FALSE`, because it loads them itself, but this does not help the subprocess.

* `test_package` is always `NULL` in the subprocess, because `devtools::test()` does not pass it, instead it passes `env` with the pre-loaded package. In this PR we set `test_package` from the `TESTTHAT_PKG` env var, a bit wonky.

*  For similar reasons, we set `load_package` to `source`, if it is `none`.

I suggest that we merge this PR, as it fixes parallel tests, and consider improvements later. All three of these are just glitches, I think, not blocking issues.