### PR TITLE
Restore `test_dir(..., wrap = FALSE)`

### DIFF
--- a/R/parallel.R
+++ b/R/parallel.R
@@ -41,6 +41,7 @@ test_files_parallel <- function(
                        env = NULL,
                        stop_on_failure = FALSE,
                        stop_on_warning = FALSE,
+                       wrap = TRUE,  # unused, to match test_files_serial
                        load_package = c("none", "installed", "source")
                        ) {
 

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -41,7 +41,7 @@ test_files_parallel <- function(
                        env = NULL,
                        stop_on_failure = FALSE,
                        stop_on_warning = FALSE,
-                       wrap = TRUE,  # unused, to match test_files_serial
+                       wrap = TRUE,  # unused, to match test_files signature
                        load_package = c("none", "installed", "source")
                        ) {
 

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -71,7 +71,7 @@ test_files_parallel <- function(
   )
 
   with_reporter(reporters$multi, {
-    parallel_update <- reporter$capabilities$parallel_update
+    parallel_update <- reporter$capabilities$parallel_updates
     if (parallel_update) {
       parallel_event_loop_smooth(queue, reporters)
     } else {

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -71,7 +71,7 @@ test_files_parallel <- function(
   )
 
   with_reporter(reporters$multi, {
-    parallel_update <- reporter$capabilities$parallel_updates
+    parallel_update <- reporter$capabilities$parallel_update
     if (parallel_update) {
       parallel_event_loop_smooth(queue, reporters)
     } else {

--- a/R/test-files.R
+++ b/R/test-files.R
@@ -191,7 +191,7 @@ test_files_serial <- function(test_dir,
                        env = NULL,
                        stop_on_failure = FALSE,
                        stop_on_warning = FALSE,
-                       wrap = FALSE,
+                       wrap = TRUE,
                        load_package = c("none", "installed", "source")) {
 
   env <- test_files_setup_env(test_package, test_dir, load_package, env)
@@ -264,7 +264,7 @@ test_files_check <- function(results, stop_on_failure = TRUE, stop_on_warning = 
   invisible(results)
 }
 
-test_one_file <- function(path, env = test_env(), wrap = FALSE) {
+test_one_file <- function(path, env = test_env(), wrap = TRUE) {
   reporter <- get_reporter()
   on.exit(teardown_run(), add = TRUE)
 

--- a/R/test-files.R
+++ b/R/test-files.R
@@ -82,6 +82,10 @@ test_dir <- function(path,
     abort("No test files found")
   }
 
+  if (!is_missing(wrap)) {
+    lifecycle::deprecate_warn("3.0.0", "test_dir(wrap = )")
+  }
+
   want_parallel <- find_parallel(path, load_package, package)
 
   if (is.null(reporter)) {
@@ -93,22 +97,6 @@ test_dir <- function(path,
   }
   reporter <- find_reporter(reporter)
   parallel <- want_parallel && reporter$capabilities$parallel_support
-
-  if (parallel) {
-    if (!is_missing(wrap)) {
-      lifecycle::deprecate_stop(
-        "3.0.0", "test_dir(wrap = )",
-        details=paste0(
-          "`wrap = ` may only be used with serial tests, but detected that  ",
-          "parallel tests requested."
-        )
-      )
-    }
-  } else {
-    if (!is_missing(wrap)) {
-      lifecycle::deprecate_warn("3.0.0", "test_file(wrap = )")
-    }
-  }
 
   test_files(
     test_dir = path,
@@ -163,18 +151,18 @@ test_files <- function(test_dir,
                        env = NULL,
                        stop_on_failure = FALSE,
                        stop_on_warning = FALSE,
-                       wrap = lifecycle::deprecated(),
+                       wrap = TRUE,
                        load_package = c("none", "installed", "source"),
                        parallel = FALSE) {
 
-  if(is_missing(wrap)) {
+  if (is_missing(wrap)) {
     wrap <- TRUE
   }
+  if (!isTRUE(wrap)) {
+    lifecycle::deprecate_warn("3.0.0", "test_dir(wrap = )")
+  }
+
   if (parallel) {
-    if(!isTRUE(wrap)) {
-      warning('`wrap` must be TRUE in parallel mode.')
-      wrap <- TRUE
-    }
     test_files <- test_files_parallel
   } else {
     test_files <- test_files_serial

--- a/R/test-files.R
+++ b/R/test-files.R
@@ -94,6 +94,22 @@ test_dir <- function(path,
   reporter <- find_reporter(reporter)
   parallel <- want_parallel && reporter$capabilities$parallel_support
 
+  if (parallel) {
+    if (!is_missing(wrap)) {
+      lifecycle::deprecate_stop(
+        "3.0.0", "test_dir(wrap = )",
+        details=paste0(
+          "`wrap = ` may only be used with serial tests, but detected that  ",
+          "parallel tests requested."
+        )
+      )
+    }
+  } else {
+    if (!is_missing(wrap)) {
+      lifecycle::deprecate_warn("3.0.0", "test_file(wrap = )")
+    }
+  }
+
   test_files(
     test_dir = path,
     test_paths = test_paths,
@@ -151,22 +167,17 @@ test_files <- function(test_dir,
                        load_package = c("none", "installed", "source"),
                        parallel = FALSE) {
 
+  if(is_missing(wrap)) {
+    wrap <- TRUE
+  }
   if (parallel) {
-    if (!is_missing(wrap)) {
-      lifecycle::deprecate_stop(
-        "3.0.0", "test_files(wrap = )",
-        details="`wrap = ` may only be used with `parallel = FALSE`"
-      )
+    if(!isTRUE(wrap)) {
+      warning('`wrap` must be TRUE in parallel mode.')
+      wrap <- TRUE
     }
     test_files <- test_files_parallel
   } else {
-    if (!is_missing(wrap)) {
-      lifecycle::deprecate_warn("3.0.0", "test_files(wrap = )")
-    }
     test_files <- test_files_serial
-  }
-  if(is_missing(wrap)) {
-    wrap <- TRUE
   }
 
   test_files(

--- a/R/utils.R
+++ b/R/utils.R
@@ -71,7 +71,7 @@ remove_source <- function(x) {
   }
 }
 
-# Need to stip environment and source references to make lightweight
+# Need to strip environment and source references to make lightweight
 # function suitable to send to another process
 transport_fun <- function(f) {
   environment(f) <- .GlobalEnv

--- a/tests/testthat/test-parallel-outside.R
+++ b/tests/testthat/test-parallel-outside.R
@@ -4,7 +4,7 @@ test_that("error outside of test_that()", {
   err <- tryCatch(
     suppressMessages(testthat::test_local(
       test_path("test-parallel", "outside"),
-      reporter = "silent"
+      # reporter = "silent"
     )),
     error = function(e) e
   )

--- a/tests/testthat/test-parallel-outside.R
+++ b/tests/testthat/test-parallel-outside.R
@@ -4,7 +4,7 @@ test_that("error outside of test_that()", {
   err <- tryCatch(
     suppressMessages(testthat::test_local(
       test_path("test-parallel", "outside"),
-      # reporter = "silent"
+      reporter = "silent"
     )),
     error = function(e) e
   )


### PR DESCRIPTION
In some unusual cases it is useful to be able to preserve the
original `testthat` behavior of not wrapping expressions outside
of `test_that` blocks.

In commit 37cc0d04fc497edcf62fe44729c73e3c77559b2e 
control of the  `wrap` functionality was removed from `test_dir`,
but after discussion in #498 it was restored.

More recently, b13ecb38c7ba49d48d12e3c97dcfa081a9634bba
removed the `wrap` functionality again from `test_dir`.  This patch
seeks to restore the functionality for serial tests only as restoring it
for parallel tests is more complicated and of dubious value since
a) the parameter is now deprecated, and b) parallel tests did not
exist prior to deprecation.

Bonus typo fixes.