### PR TITLE
Change spinner color to red if we know there are failures

### DIFF
--- a/R/reporter-progress.R
+++ b/R/reporter-progress.R
@@ -129,9 +129,9 @@ ProgressReporter <- R6::R6Class("ProgressReporter",
         }
         status <- spinner(self$frames, data$n)
         if (data$n_fail > 0) {
-          status <- crayon::red(status)
+          status <- colourise(status, "failure")
         } else if (data$n_warn > 0) {
-          status <- crayon::magenta(status)
+          status <- colourise(status, "warning")
         }
       }
 

--- a/R/reporter-progress.R
+++ b/R/reporter-progress.R
@@ -130,6 +130,8 @@ ProgressReporter <- R6::R6Class("ProgressReporter",
         status <- spinner(self$frames, data$n)
         if (data$n_fail > 0) {
           status <- crayon::red(status)
+        } else if (data$n_warn > 0) {
+          status <- crayon::magenta(status)
         }
       }
 

--- a/R/reporter-progress.R
+++ b/R/reporter-progress.R
@@ -128,6 +128,9 @@ ProgressReporter <- R6::R6Class("ProgressReporter",
           return()
         }
         status <- spinner(self$frames, data$n)
+        if (data$n_fail > 0) {
+          status <- crayon::red(status)
+        }
       }
 
       col_format <- function(n, type) {
@@ -191,7 +194,6 @@ ProgressReporter <- R6::R6Class("ProgressReporter",
       } else if (expectation_skip(result)) {
         self$n_skip <- self$n_skip + 1
         self$ctxt_n_skip <- self$ctxt_n_skip + 1
-        self$ctxt_issues$push(result)
         self$skips$push(result$message)
       } else if (expectation_warning(result)) {
         self$n_warn <- self$n_warn + 1

--- a/R/reporter-progress.R
+++ b/R/reporter-progress.R
@@ -194,6 +194,7 @@ ProgressReporter <- R6::R6Class("ProgressReporter",
       } else if (expectation_skip(result)) {
         self$n_skip <- self$n_skip + 1
         self$ctxt_n_skip <- self$ctxt_n_skip + 1
+        self$ctxt_issues$push(result)
         self$skips$push(result$message)
       } else if (expectation_warning(result)) {
         self$n_warn <- self$n_warn + 1


### PR DESCRIPTION
Ideally we would print errors as we see them, to give as early feedback as possible. If a test file runs 10 seconds, that's precious time wasted that could be spent reviewing the error instead.