### PR TITLE
Fix parallel cleanup: ignore failed workers

### DIFF
--- a/R/parallel.R
+++ b/R/parallel.R
@@ -269,8 +269,12 @@ queue_teardown <- function(queue) {
   topoll <- list()
   for (i in seq_len(num)) {
     if (!is.null(tasks$worker[[i]])) {
-      tasks$worker[[i]]$call(clean_fn)
-      topoll <- c(topoll, tasks$worker[[i]]$get_poll_connection())
+      # The worker might have crashed or exited, so this might fail.
+      # If it does then we'll just ignore that worker
+      tryCatch({
+        tasks$worker[[i]]$call(clean_fn)
+        topoll <- c(topoll, tasks$worker[[i]]$get_poll_connection())
+      }, error = function(e) tasks$worker[i] <- list(NULL))
     }
   }
 


### PR DESCRIPTION
If a worker has crashed or exited, then we cannot
run the teardown files in it. Now we ignore such
workers, so we at least tear down the rest.

This also fixes test failures with newer withr,
that fails if the deferred queue teardown errors.