### PR TITLE
Works around test failure with warnPartialMatchArgs

### DIFF
--- a/tests/testthat/test-expect-equality.R
+++ b/tests/testthat/test-expect-equality.R
@@ -43,6 +43,10 @@ test_that("can control numeric tolerance", {
   expect_success(expect_equal(x1, x2, tolerance = 1e-5))
   expect_success(expect_equivalent(x1, x2, tolerance = 1e-5))
   # with partial matching
+  # we work around https://github.com/r-lib/testthat/issues/1188
+  if (getRversion() < "3.6.0" && is.null(getOption("warnPartialMatchArgs"))) {
+    options(warnPartialMatchArgs = FALSE)
+  }
   withr::local_options(list(warnPartialMatchArgs = FALSE))
   expect_success(expect_equal(x1, x2, tol = 1e-5))
 


### PR DESCRIPTION
R 3.5.3 and older fails for
```r
options(warnPartialMatchArgs = NULL)
```
and now that withr does not ignore failures, our test
case that sets
```r
  withr::local_options(list(warnPartialMatchArgs = FALSE))
```

We work around this by setting the default value explicitly on
these R versions.

Closes #1188.