### PR TITLE
Skip some parallel tests in covr

### DIFF
--- a/tests/testthat/test-parallel-crash.R
+++ b/tests/testthat/test-parallel-crash.R
@@ -1,6 +1,7 @@
 
 test_that("crash", {
   skip_on_cran()
+  skip_on_covr()
   withr::local_envvar(c(TESTTHAT_PARALLEL = "TRUE"))
 
   do <- function() {

--- a/tests/testthat/test-parallel-setup.R
+++ b/tests/testthat/test-parallel-setup.R
@@ -1,5 +1,6 @@
 
 test_that("error in parallel setup code", {
+  skip_on_covr()
   withr::local_envvar(c(TESTTHAT_PARALLEL = "TRUE"))
   err <- tryCatch(
     suppressMessages(testthat::test_local(

--- a/tests/testthat/test-parallel-startup.R
+++ b/tests/testthat/test-parallel-startup.R
@@ -1,5 +1,6 @@
 
 test_that("startup error", {
+  skip_on_covr()
   withr::local_envvar(c(TESTTHAT_PARALLEL = "TRUE"))
   err <- tryCatch(
     suppressMessages(testthat::test_local(


### PR DESCRIPTION
These tests clean up the remaining test subprocesses,
after one of them has crashed, and then these
leave behind incomplete coverage data files and covr
errors on these.