### PR TITLE
Set cli.width in the reproducible context

### DIFF
--- a/R/local.R
+++ b/R/local.R
@@ -121,7 +121,7 @@ waldo_compare <- function(x, y, ..., x_arg = "x", y_arg = "y") {
 }
 
 local_width <- function(width = 80, .env = parent.frame()) {
-  withr::local_options(list(width = width), .local_envir = .env)
+  withr::local_options(list(width = width, cli.width = width), .local_envir = .env)
   withr::local_envvar(list(RSTUDIO_CONSOLE_WIDTH = width), .local_envir = .env)
 }
 


### PR DESCRIPTION
In dev cli `console_width()` prefers the real console width
on some platforms over `getOption("width")`, so we need to
set the `cli.width` option to make the width reproducible.