### PR TITLE
More conservative worker pool size

### DIFF
--- a/R/parallel.R
+++ b/R/parallel.R
@@ -88,12 +88,12 @@ test_files_parallel <- function(
 default_num_cpus <- function() {
   # Use common option, if set
   ncpus <- getOption("Ncpus", NULL)
-  if (!is.null(ncpus) && !is_integer(ncpus)) {
+  if (!is.null(ncpus) && !is.numeric(ncpus)) {
     stop("`getOption(Ncpus)` must be integer")
   }
 
   if (!is.null(ncpus)) {
-    return(ncpus)
+    return(as.integer(ncpus))
   }
 
   # Otherwise detect. If we cannot detect, then compromise.

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -88,30 +88,22 @@ test_files_parallel <- function(
 default_num_cpus <- function() {
   # Use common option, if set
   ncpus <- getOption("Ncpus", NULL)
-  if (!is.null(ncpus) && !is.numeric(ncpus)) {
-    stop("`getOption(Ncpus)` must be integer")
-  }
-
   if (!is.null(ncpus)) {
-    return(as.integer(ncpus))
+    ncpus <- suppressWarnings(as.integer(ncpus))
+    if (is.na(ncpus)) abort("`getOption(Ncpus)` must be an integer")
+    return(ncpus)
   }
 
-  # Otherwise detect. If we cannot detect, then compromise.
-  if (ps::ps_is_supported()) {
-    ncpus <- ps::ps_cpu_count()
-  } else {
-    ncpus <- 2L
+  # Otherwise use env var if set
+  ncpus <- Sys.getenv("TESTTHAT_CPUS", "")
+  if (ncpus != "") {
+    ncpus <- suppressWarnings(as.integer(ncpus))
+    if (is.na(ncpus)) abort("TESTTHAT_CPUS must be an integer")
+    return(ncpus)
   }
 
-  # But allow capping with an env var
-  max_env <- Sys.getenv("TESTTHAT_MAX_CPUS", "")
-  if (max_env != "") {
-    max_env <- as.integer(max_env)
-    if (is.na(max_env)) abort("TESTTHAT_MAX_CPUS must be an integer")
-    ncpus <- min(ncpus, max_env)
-  }
-
-  ncpus
+  # Otherwise 2
+  2L
 }
 
 parallel_event_loop_smooth <- function(queue, reporters) {

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -1,27 +1,25 @@
 
 test_that("detect number of cpus to use", {
 
-  mockery::stub(default_num_cpus, "ps::ps_cpu_count", 50)
-
   withr::local_options(list(Ncpus = 100L))
-  withr::local_envvar(list(TESTTHAT_MAX_CPUS = NA))
+  withr::local_envvar(list(TESTTHAT_CPUS = NA))
   expect_equal(default_num_cpus(), 100L)
 
   withr::local_options(list(Ncpus = 100L))
-  withr::local_envvar(list(TESTTHAT_MAX_CPUS = 10))
+  withr::local_envvar(list(TESTTHAT_CPUS = 10))
   expect_equal(default_num_cpus(), 100L)
 
   withr::local_options(list(Ncpus = NULL))
-  withr::local_envvar(list(TESTTHAT_MAX_CPUS = NA))
-  expect_equal(default_num_cpus(), 50)
+  withr::local_envvar(list(TESTTHAT_CPUS = NA))
+  expect_equal(default_num_cpus(), 2L)
 
   withr::local_options(list(Ncpus = NULL))
-  withr::local_envvar(list(TESTTHAT_MAX_CPUS = NA))
-  expect_equal(default_num_cpus(), 50)
+  withr::local_envvar(list(TESTTHAT_CPUS = NA))
+  expect_equal(default_num_cpus(), 2L)
 
   withr::local_options(list(Ncpus = NULL))
-  withr::local_envvar(list(TESTTHAT_MAX_CPUS = 13))
-  expect_equal(default_num_cpus(), 13)
+  withr::local_envvar(list(TESTTHAT_CPUS = 13))
+  expect_equal(default_num_cpus(), 13L)
 })
 
 test_that("ok", {

--- a/vignettes/parallel.Rmd
+++ b/vignettes/parallel.Rmd
@@ -26,7 +26,8 @@ You'll also need to be using the 3rd edition:
 ## Basic operation
 
 Starting a new R process is relatively expensive, so testthat begins by creating a pool of workers.
-The size of the pool will be determined by `getOption("Ncpus")`, then the `TESTTHAT_MAX_CPUS` envvar, then the number of processes reported by `ps::ps_cpu_count()`.
+The size of the pool will be determined by `getOption("Ncpus")`, then the `TESTTHAT_CPUS` envvar.
+If neither are set, then two processes are started.
 In any case, testthat will never start more subprocesses than test files.
 
 Each worker begins by loading testthat and the package being tested.


### PR DESCRIPTION
* Take `getOption(Ncpus)` first.
* Otherwise take the `TESTTHAT_CPUS` env var.
* Otherwise start two processes.

Also, allow non-integer `Ncpus` option. (I.e. `options(Ncpus = 4)` should work.)