### PR TITLE
Typo in auto_test_package()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # testthat (development version)
 
+* Fixed a couple of buglets in `auto_test_pacakge()` (@mbojan, #1211, #1214)
+
 # testthat 3.0.0
 
 ## 3rd edition

--- a/R/auto-test.R
+++ b/R/auto-test.R
@@ -75,7 +75,7 @@ auto_test <- function(code_path, test_path, reporter = default_reporter(),
 auto_test_package <- function(pkg = ".", reporter = default_reporter(), hash = TRUE) {
   reporter <- find_reporter(reporter)
 
-  path <- pkgload::pkg_path(path)
+  path <- pkgload::pkg_path(pkg)
   package <- pkgload::pkg_name(path)
 
   code_path <- file.path(path, c("R", "src"))

--- a/R/auto-test.R
+++ b/R/auto-test.R
@@ -86,7 +86,7 @@ auto_test_package <- function(pkg = ".", reporter = default_reporter(), hash = T
   # Start by loading all code and running all tests
   withr::local_envvar(list("NOT_CRAN" = "true"))
   pkgload::load_all(path)
-  test_dir(test_path, package = package, reporter = reporter$clone(deep = TRUE))
+  test_dir(test_path, package = package, reporter = reporter$clone(deep = TRUE), stop_on_failure = FALSE)
 
   # Next set up watcher to monitor changes
   watcher <- function(added, deleted, modified) {


### PR DESCRIPTION
Typo in `auto_test_package()`. Fixes #1211.
Make `auto_test_package()` not stop on failure. Fixes #1214.