### PR TITLE
remove get_proj() from case study

### DIFF
--- a/vignettes/test-fixtures.Rmd
+++ b/vignettes/test-fixtures.Rmd
@@ -265,7 +265,7 @@ To solve this problem we create a test fixture, which we place in `R/test-helper
 
 ```{r, eval = FALSE}
 local_create_package <- function(dir = file_temp(), env = parent.frame()) {
-  old_project <- proj_get_()
+  old_wd <- getwd()
   
   # create new folder and package
   create_package(dir, open = FALSE) # A
@@ -273,11 +273,7 @@ local_create_package <- function(dir = file_temp(), env = parent.frame()) {
   
   # change working directory
   setwd(dir) # B
-  withr::defer(setwd(old_project), envir = env) # -B
-  
-  # switch to new usethis project
-  proj_set(dir) # C
-  withr::defer(proj_set(old_project, force = TRUE), envir = env) # -C
+  withr::defer(setwd(old_wd), envir = env) # -B
   
   dir
 }

--- a/vignettes/test-fixtures.Rmd
+++ b/vignettes/test-fixtures.Rmd
@@ -279,7 +279,7 @@ local_create_package <- function(dir = file_temp(), env = parent.frame()) {
 }
 ```
 
-Note that the cleanup automatically unfolds in the opposite order from the setup. Setup is `A`, then `B`, then `C`; cleanup is `-C`, then `-B`, then `-A`. This is important because we must create directory `dir` before we can make it the working directory; and we must restore the original working directory before we can delete `dir`; we can't delete `dir` while it's still the working directory!
+Note that the cleanup automatically unfolds in the opposite order from the setup. Setup is `A`, then `B`; cleanup is `-B`, then `-A`. This is important because we must create directory `dir` before we can make it the working directory; and we must restore the original working directory before we can delete `dir`; we can't delete `dir` while it's still the working directory!
 
 `create_local_package()` is used in over 170 tests. Here's one example that checks that `usethis::use_roxygen_md()` does the setup necessary to use roxygen2 in a package, with markdown support turned on. All 3 expectations consult the DESCRIPTION file, directly or indirectly. So it's very convenient that `create_local_package()` creates a minimal package, with a valid `DESCRIPTION` file, for us to test against. And when the test is done --- poof! --- the package is gone.
 


### PR DESCRIPTION
I'm not sure about the use inside usethis, but when I try this locally inside `devtools::check()` this fails, because there is no project inside the temp dir where the check is run.
So this might be a bit misleading as an example.