### PR TITLE
Fix ARM64 detection on Apple platforms in catch.h

### DIFF
--- a/inst/include/testthat/vendor/catch.h
+++ b/inst/include/testthat/vendor/catch.h
@@ -2107,8 +2107,13 @@ namespace Catch{
         #define CATCH_TRAP() \
                 __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n" \
                 : : : "memory","r0","r3","r4" )
-    #else
-        #define CATCH_TRAP() __asm__("int $3\n" : : )
+    // backported from Catch2
+    // revision b9853b4b356b83bb580c746c3a1f11101f9af54f
+    // src/catch2/internal/catch_debugger.hpp
+    #elif defined(__i386__) || defined(__x86_64__)
+        #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
+    #elif defined(__aarch64__)
+        #define CATCH_TRAP()  __asm__(".inst 0xd4200000")
     #endif
 
 #elif defined(CATCH_PLATFORM_LINUX)


### PR DESCRIPTION
Old catch.h header assumed that all Mac platforms are x86-based, which would lead to compile errors on Apple Silicon Macs. This change back ports the definition of  `CATCH_TRAP` used in newer Catch2, which correctly accounts for the ARM-based Apple platforms.

All tests pass on my Intel and my M1-based Mac (except the X11 test since I don't have X11 installed on the later). 

This closes issue https://github.com/r-lib/testthat/issues/1244