### PR TITLE
skip_if_not(): do not append " is not TRUE" to custom message

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # testthat (development version)
 
+* `skip_if_not()` no longer appends "is not TRUE" to custom messages 
+  (@dpprdan, #1247).
+
 * `expect_snapshot_value()` now passes `...` on to `waldo::compare()` (#1222).
 
 * Fixed a couple of buglets in `auto_test_pacakge()` (@mbojan, #1211, #1214)

--- a/R/skip.R
+++ b/R/skip.R
@@ -78,7 +78,7 @@ skip_empty <- function() {
 #'   `FALSE`, `skip_if()` will skip if `TRUE`.
 skip_if_not <- function(condition, message = NULL) {
   if (is.null(message)) {
-    message <- paste(deparse(substitute(condition)), " is not TRUE")
+    message <- paste0(deparse(substitute(condition)), " is not TRUE")
   }
   if (!isTRUE(condition)) {
     skip(message)
@@ -89,7 +89,7 @@ skip_if_not <- function(condition, message = NULL) {
 #' @rdname skip
 skip_if <- function(condition, message = NULL) {
   if (is.null(message)) {
-    message <- paste(deparse(substitute(condition)), " is TRUE")
+    message <- paste0(deparse(substitute(condition)), " is TRUE")
   }
   if (isTRUE(condition)) {
     skip(message)

--- a/R/skip.R
+++ b/R/skip.R
@@ -76,8 +76,10 @@ skip_empty <- function() {
 #' @rdname skip
 #' @param condition Boolean condition to check. `skip_if_not()` will skip if
 #'   `FALSE`, `skip_if()` will skip if `TRUE`.
-skip_if_not <- function(condition, message = deparse(substitute(condition))) {
-  message <- paste0(message, " is not TRUE")
+skip_if_not <- function(condition, message = NULL) {
+  if (is.null(message)) {
+    message <- paste(deparse(substitute(condition)), " is not TRUE")
+  }
   if (!isTRUE(condition)) {
     skip(message)
   }

--- a/R/skip.R
+++ b/R/skip.R
@@ -1,52 +1,46 @@
-#' Skip a test.
+#' Skip a test
 #'
-#' This function allows you to skip a test if it's not currently available.
-#' This will produce an informative message, but will not cause the test
-#' suite to fail.
+#' @description
+#' `skip_if()` and `skip_if_not()` allow you to skip tests, immediately
+#' concluding a [test_that()] block without executing any further expectations.
+#' This allows you to skip a test without failure, if for some reason it
+#' can't be run (e.g. it depends on the feature of a specific operating system,
+#' or it requires a specific version of a package).
 #'
-#' `skip*` functions are intended for use within [test_that()]
-#' blocks.  All expectations following the \code{skip*} statement within the
-#' same `test_that` block will be skipped.  Test summaries that report skip
-#' counts are reporting how many `test_that` blocks triggered a `skip*`
-#' statement, not how many expectations were skipped.
+#' See `vignette("skipping")` for more details.
 #'
 #' @section Helpers:
-#' `skip_if_not()` works like [stopifnot()], generating
-#' a message automatically based on the first argument.
 #'
-#' `skip_if_offline()` skips tests if an internet connection is not available
-#' using [curl::nslookup()].
+#' * `skip_if_not_installed("pkg")` skips tests if package "pkg" is not
+#'   installed or cannot be loaded (using `requireNamespace()`). Generally,
+#'   you can assume that suggested packages are installed, and you do not
+#'   need to check for them specifically, unless they are particularly
+#'   difficult to install.
 #'
-#' `skip_on_cran()` skips tests on CRAN, using the `NOT_CRAN`
-#' environment variable set by devtools.
+#' * `skip_if_offline()` skips if an internet connection is not available
+#'   (using [curl::nslookup()]).
 #'
-#' `skip_on_travis()` skips tests on Travis CI by inspecting the
-#' `TRAVIS` environment variable.
+#' * `skip_if_translated("msg")` skips tests if the "msg" is translated.
 #'
-#' `skip_on_appveyor()` skips tests on AppVeyor by inspecting the
-#' `APPVEYOR` environment variable.
+#' * `skip_on_bioc()` skips on Bioconductor (using the `BBS_HOME` env var).
 #'
-#' `skip_on_ci()` skips tests on continuous integration systems by inspecting
-#' the `CI` environment variable.
+#' * `skip_on_cran()` skips on CRAN (using the `NOT_CRAN` env var set by
+#'    devtools and friends).
 #'
-#' `skip_on_covr()` skips tests when covr is running by inspecting the
-#' `R_COVR` environment variable
+#' * `skip_on_covr()` skips when covr is running (using the `R_COVR` env var).
 #'
-#' `skip_on_bioc()` skips tests on Bioconductor by inspecting the
-#' `BBS_HOME` environment variable.
+#' * `skip_on_ci()` skips on continuous integration systems like GitHub Actions,
+#'    travis, and appveyor (using the `CI` env var). It supersedes the older
+#'    `skip_on_travis()` and `skip_on_appveyor()` functions.
 #'
-#' `skip_if_not_installed()` skips a tests if a package is not installed
-#' or cannot be loaded (useful for suggested packages).  It loads the package as
-#' a side effect, because the package is likely to be used anyway.
+#' * `skip_on_os()` skips on the specified operating system(s) ("windows",
+#'   "mac", "linux", or "solaris").
 #'
 #' @param message A message describing why the test was skipped.
 #' @param host A string with a hostname to lookup
 #' @export
 #' @examples
 #' if (FALSE) skip("No internet connection")
-#'
-#' ## The following are only meaningful when put in test files and
-#' ## run with `test_file`, `test_dir`, `test_check`, etc.
 #'
 #' test_that("skip example", {
 #'   expect_equal(1, 1L)    # this expectation runs
@@ -148,7 +142,7 @@ skip_on_os <- function(os) {
   sysname <- tolower(Sys.info()[["sysname"]])
 
   switch(sysname,
-    windows = if ("windows" %in% os) skip("On windows"),
+    windows = if ("windows" %in% os) skip("On Windows"),
     darwin =  if ("mac" %in% os) skip("On Mac"),
     linux =   if ("linux" %in% os) skip("On Linux"),
     sunos =   if ("solaris" %in% os) skip("On Solaris")

--- a/man/skip.Rd
+++ b/man/skip.Rd
@@ -14,11 +14,11 @@
 \alias{skip_on_covr}
 \alias{skip_on_bioc}
 \alias{skip_if_translated}
-\title{Skip a test.}
+\title{Skip a test}
 \usage{
 skip(message)
 
-skip_if_not(condition, message = deparse(substitute(condition)))
+skip_if_not(condition, message = NULL)
 
 skip_if(condition, message = NULL)
 
@@ -62,53 +62,39 @@ uses a message included in most translation packs. See the complete list in
 \href{https://github.com/wch/r-source/blob/master/src/library/base/po/R-base.pot}{\code{R-base.pot}}.}
 }
 \description{
-This function allows you to skip a test if it's not currently available.
-This will produce an informative message, but will not cause the test
-suite to fail.
-}
-\details{
-\verb{skip*} functions are intended for use within \code{\link[=test_that]{test_that()}}
-blocks.  All expectations following the \code{skip*} statement within the
-same \code{test_that} block will be skipped.  Test summaries that report skip
-counts are reporting how many \code{test_that} blocks triggered a \verb{skip*}
-statement, not how many expectations were skipped.
+\code{skip_if()} and \code{skip_if_not()} allow you to skip tests, immediately
+concluding a \code{\link[=test_that]{test_that()}} block without executing any further expectations.
+This allows you to skip a test without failure, if for some reason it
+can't be run (e.g. it depends on the feature of a specific operating system,
+or it requires a specific version of a package).
+
+See \code{vignette("skipping")} for more details.
 }
 \section{Helpers}{
 
-\code{skip_if_not()} works like \code{\link[=stopifnot]{stopifnot()}}, generating
-a message automatically based on the first argument.
-
-\code{skip_if_offline()} skips tests if an internet connection is not available
-using \code{\link[curl:nslookup]{curl::nslookup()}}.
-
-\code{skip_on_cran()} skips tests on CRAN, using the \code{NOT_CRAN}
-environment variable set by devtools.
-
-\code{skip_on_travis()} skips tests on Travis CI by inspecting the
-\code{TRAVIS} environment variable.
-
-\code{skip_on_appveyor()} skips tests on AppVeyor by inspecting the
-\code{APPVEYOR} environment variable.
-
-\code{skip_on_ci()} skips tests on continuous integration systems by inspecting
-the \code{CI} environment variable.
-
-\code{skip_on_covr()} skips tests when covr is running by inspecting the
-\code{R_COVR} environment variable
-
-\code{skip_on_bioc()} skips tests on Bioconductor by inspecting the
-\code{BBS_HOME} environment variable.
-
-\code{skip_if_not_installed()} skips a tests if a package is not installed
-or cannot be loaded (useful for suggested packages).  It loads the package as
-a side effect, because the package is likely to be used anyway.
+\itemize{
+\item \code{skip_if_not_installed("pkg")} skips tests if package "pkg" is not
+installed or cannot be loaded (using \code{requireNamespace()}). Generally,
+you can assume that suggested packages are installed, and you do not
+need to check for them specifically, unless they are particularly
+difficult to install.
+\item \code{skip_if_offline()} skips if an internet connection is not available
+(using \code{\link[curl:nslookup]{curl::nslookup()}}).
+\item \code{skip_if_translated("msg")} skips tests if the "msg" is translated.
+\item \code{skip_on_bioc()} skips on Bioconductor (using the \code{BBS_HOME} env var).
+\item \code{skip_on_cran()} skips on CRAN (using the \code{NOT_CRAN} env var set by
+devtools and friends).
+\item \code{skip_on_covr()} skips when covr is running (using the \code{R_COVR} env var).
+\item \code{skip_on_ci()} skips on continuous integration systems like GitHub Actions,
+travis, and appveyor (using the \code{CI} env var). It supersedes the older
+\code{skip_on_travis()} and \code{skip_on_appveyor()} functions.
+\item \code{skip_on_os()} skips on the specified operating system(s) ("windows",
+"mac", "linux", or "solaris").
+}
 }
 
 \examples{
 if (FALSE) skip("No internet connection")
-
-## The following are only meaningful when put in test files and
-## run with `test_file`, `test_dir`, `test_check`, etc.
 
 test_that("skip example", {
   expect_equal(1, 1L)    # this expectation runs

--- a/vignettes/skipping.Rmd
+++ b/vignettes/skipping.Rmd
@@ -34,7 +34,7 @@ testthat comes with a variety of helpers for the most common situations:
 
 -   `skip_on_os()` allows you to skip tests on a specific operating system. Generally, you should strive to avoid this as much as possible (so your code works the same on all platforms), but sometimes it's just not possible.
 
--   `skip_on_ci()` skips tests on most continuous integration platforms (e.g. Travis, Appveyor, GitHub actions).
+-   `skip_on_ci()` skips tests on most continuous integration platforms (e.g. GitHub Actions, Travis, Appveyor).
 
 You can also easily implement your own using either `skip_if()` or `skip_if_not()`, which both take an expression that should yield a single `TRUE` or `FALSE`.
 


### PR DESCRIPTION
fixes #1247 

I noticed that `skip_if()`, `skip_if_translated()` and `skip_on_os()` are missing in the `@helpers` section. Should I add them there, while I am at it?

Should/could there be a `skip_on_github_actions()` (in a separate PR)? 