### PR TITLE
Don't truncate test names in CheckReporter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # testthat (development version)
 
+* `CheckReporter` now always shows the full test name (#1268).
+
 * `expect_snapshot()` gains new `error` argument which controls whether or not
   an error is expected. If an unexpected error is thrown, or an expected error
   is not thrown, `expect_snapshot()` will fail (even on CRAN) (#1200).

--- a/R/reporter-check.R
+++ b/R/reporter-check.R
@@ -44,7 +44,8 @@ CheckReporter <- R6::R6Class("CheckReporter",
       }
 
       type <- expectation_type(result)
-      header <- cli::rule(issue_header(result))
+      msg <- issue_header(result)
+      header <- cli::rule(msg, width = max(nchar(msg) + 6, 80))
 
       self$local_user_output()
       self$cat_line(header)

--- a/tests/testthat/_snaps/reporter-check.md
+++ b/tests/testthat/_snaps/reporter-check.md
@@ -45,3 +45,13 @@
     
     [ FAIL 4 | WARN 1 | SKIP 2 | PASS 1 ]
 
+# doesn't truncate long lines
+
+    -- FAILURE (long-test.R:2:3): That very long test messages are not truncated because they contain useful information that you probably want to read --
+    Failure has been forced
+    
+    == testthat results  ===========================================================
+    FAILURE (long-test.R:2:3): That very long test messages are not truncated because they contain useful information that you probably want to read
+    
+    [ FAIL 1 | WARN 0 | SKIP 0 | PASS 0 ]
+

--- a/tests/testthat/reporters/long-test.R
+++ b/tests/testthat/reporters/long-test.R
@@ -1,0 +1,3 @@
+test_that("That very long test messages are not truncated because they contain useful information that you probably want to read", {
+  fail()
+})

--- a/tests/testthat/test-reporter-check.R
+++ b/tests/testthat/test-reporter-check.R
@@ -1,7 +1,13 @@
 test_that("basic report works", {
+  on.exit(unlink(test_path("testthat-problems.rds")))
   expect_snapshot_reporter(CheckReporter$new())
 
   rds <- test_path("testthat-problems.rds")
   expect_true(file.exists(rds))
-  unlink(rds)
+})
+
+test_that("doesn't truncate long lines", {
+  on.exit(unlink(test_path("testthat-problems.rds")))
+
+  expect_snapshot_reporter(CheckReporter$new(), test_path("reporters/long-test.R"))
 })


### PR DESCRIPTION
@krlmlr is this what you were expecting?

Fixes #1268