### PR TITLE
Remove old testthat-problems.rds

### DIFF
--- a/R/reporter-check.R
+++ b/R/reporter-check.R
@@ -57,6 +57,8 @@ CheckReporter <- R6::R6Class("CheckReporter",
         self$rule("Failed tests", line = 2)
         self$cat_line(map_chr(problems, issue_summary, rule = TRUE, simplify = "none"))
         self$cat_line()
+      } else {
+        unlink("testthat-problems.rds")
       }
 
       self$cat_line(summary_line(


### PR DESCRIPTION
once tests are successful.

Are old tests results of any use?