### PR TITLE
Avoid partial match warning

### DIFF
--- a/R/reporter-progress.R
+++ b/R/reporter-progress.R
@@ -439,7 +439,7 @@ ParallelProgressReporter <- R6::R6Class("ParallelProgressReporter",
         self$files[[file]]$issues$push(result)
       } else if (expectation_skip(result)) {
         self$n_skip <- self$n_skip + 1
-        self$files[[file]]$n_skip <- self$files[[file]]$n_skip + 1L
+        self$files[[file]]$n_skip_ <- self$files[[file]]$n_skip_ + 1L
         if (self$verbose_skips) {
           self$files[[file]]$issues$push(result)
         }


### PR DESCRIPTION
This line generates a partial match warning because `n_skip` is defined as `n_skip_` at L386. I am assuming using the underscore was intentional there, if not an alternative solution would be to remove the underscores from the line I changed in this PR.