### PR TITLE
Collapse outputs of same type

### DIFF
--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -78,11 +78,11 @@ snapshot_replay <- function(x, state) {
 }
 #' @export
 snapshot_replay.character <- function(x, state) {
-  c("Output", indent(split_lines(x)))
+  c(snap_header(state, "Output"), indent(split_lines(x)))
 }
 #' @export
 snapshot_replay.source <- function(x, state) {
-  c("Code", indent(split_lines(x$src)))
+  c(snap_header(state, "Code"), indent(split_lines(x$src)))
 }
 #' @export
 snapshot_replay.condition <- function(x, state) {
@@ -101,7 +101,14 @@ snapshot_replay.condition <- function(x, state) {
 
   class <- paste0(type, " <", class(x)[[1]], ">")
 
-  c(class, indent(split_lines(msg)))
+  c(snap_header(state, class), indent(split_lines(msg)))
+}
+
+snap_header <- function(state, header) {
+  if (!identical(state$header, header)) {
+    state$header <- header
+    header
+  }
 }
 
 #' @export

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -27,6 +27,27 @@
     Error <rlang_error>
       4
 
+# multiple outputs of same type are collapsed
+
+    Code
+      x <- 1
+      y <- 1
+      {
+        message("a")
+        message("b")
+      }
+    Message <simpleMessage>
+      a
+      b
+    Code
+      {
+        warn("a")
+        warn("b")
+      }
+    Warning <warning>
+      a
+      b
+
 # snapshot handles multi-line input
 
     Code

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -16,6 +16,15 @@ test_that("can snapshot everything", {
   expect_snapshot(f(), error = TRUE)
 })
 
+test_that("multiple outputs of same type are collapsed", {
+  expect_snapshot({
+    x <- 1
+    y <- 1
+    {message("a"); message("b")}
+    {warn("a"); warn("b")}
+  })
+})
+
 test_that("always checks error status", {
   expect_failure(expect_snapshot(stop("!"), error = FALSE))
   expect_failure(expect_snapshot(print("!"), error = TRUE))


### PR DESCRIPTION
Fixes #1311

The primary downside is that this will force many snapshot users to update testthat quickly because their tests will start failing on CI. I think it's still worth doing it, but it requires a little thought.