### PR TITLE
Capture tracebacks for wrapped expectations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # testthat (development version)
 
+* Failing expectations now include a backtrace when they're not called directly
+  from within `test_that()` but are instead wrapped in some helper function 
+  (#1307).
+  
 * `CheckReporter` now only records warnings when not on CRAN. Otherwise 
   failed CRAN revdep checks tend to be cluttered up with warnings (#1300).
   It automatically cleans up `testthat-problems.rds` left over from previous

--- a/R/expect-comparison.R
+++ b/R/expect-comparison.R
@@ -36,7 +36,8 @@ expect_compare <- function(operator = c("<", "<=", ">", ">="), act, exp) {
   }
   expect(
     if (!is.na(cmp)) cmp else FALSE,
-    sprintf("%s is %s %s. Difference: %.3g", act$lab, msg, exp$lab, act$val - exp$val)
+    sprintf("%s is %s %s. Difference: %.3g", act$lab, msg, exp$lab, act$val - exp$val),
+    trace = test_trace(2)
   )
   invisible(act$val)
 }

--- a/R/expect-comparison.R
+++ b/R/expect-comparison.R
@@ -37,7 +37,7 @@ expect_compare <- function(operator = c("<", "<=", ">", ">="), act, exp) {
   expect(
     if (!is.na(cmp)) cmp else FALSE,
     sprintf("%s is %s %s. Difference: %.3g", act$lab, msg, exp$lab, act$val - exp$val),
-    trace_env = caller_env(1)
+    trace_env = caller_env()
   )
   invisible(act$val)
 }

--- a/R/expect-comparison.R
+++ b/R/expect-comparison.R
@@ -37,7 +37,7 @@ expect_compare <- function(operator = c("<", "<=", ">", ">="), act, exp) {
   expect(
     if (!is.na(cmp)) cmp else FALSE,
     sprintf("%s is %s %s. Difference: %.3g", act$lab, msg, exp$lab, act$val - exp$val),
-    trace = test_trace(2)
+    trace_env = caller_env(1)
   )
   invisible(act$val)
 }

--- a/R/expect-constant.R
+++ b/R/expect-constant.R
@@ -77,7 +77,8 @@ expect_waldo_constant <- function(act, constant, info) {
       act$lab, deparse(constant),
       paste0(comp, collapse = "\n\n")
     ),
-    info = info
+    info = info,
+    trace = test_trace(2)
   )
 
   invisible(act$val)

--- a/R/expect-constant.R
+++ b/R/expect-constant.R
@@ -78,7 +78,7 @@ expect_waldo_constant <- function(act, constant, info) {
       paste0(comp, collapse = "\n\n")
     ),
     info = info,
-    trace_env = caller_env(1)
+    trace_env = caller_env()
   )
 
   invisible(act$val)

--- a/R/expect-constant.R
+++ b/R/expect-constant.R
@@ -78,7 +78,7 @@ expect_waldo_constant <- function(act, constant, info) {
       paste0(comp, collapse = "\n\n")
     ),
     info = info,
-    trace = test_trace(2)
+    trace_env = caller_env(1)
   )
 
   invisible(act$val)

--- a/R/expect-equality.R
+++ b/R/expect-equality.R
@@ -123,7 +123,7 @@ expect_waldo_equal <- function(type, act, exp, info, ...) {
       paste0(comp, collapse = "\n\n")
     ),
     info = info,
-    trace_env = caller_env(1)
+    trace_env = caller_env()
   )
 
   invisible(act$val)

--- a/R/expect-equality.R
+++ b/R/expect-equality.R
@@ -122,7 +122,8 @@ expect_waldo_equal <- function(type, act, exp, info, ...) {
       exp$lab, "`expected`",
       paste0(comp, collapse = "\n\n")
     ),
-    info = info
+    info = info,
+    trace = test_trace(2)
   )
 
   invisible(act$val)

--- a/R/expect-equality.R
+++ b/R/expect-equality.R
@@ -123,7 +123,7 @@ expect_waldo_equal <- function(type, act, exp, info, ...) {
       paste0(comp, collapse = "\n\n")
     ),
     info = info,
-    trace = test_trace(2)
+    trace_env = caller_env(1)
   )
 
   invisible(act$val)

--- a/R/expect-inheritance.R
+++ b/R/expect-inheritance.R
@@ -74,8 +74,7 @@ expect_s3_class <- function(object, class, exact = FALSE) {
   } else if (is.character(class)) {
     if (!isS3(act$val)) {
       fail(sprintf("%s is not an S3 object", act$lab))
-    }
-    if (exact) {
+    } else if (exact) {
       expect(
         identical(class(act$val), class),
         sprintf("%s has class %s, not %s.", act$lab, act$class, exp_lab)
@@ -108,11 +107,12 @@ expect_s4_class <- function(object, class) {
   } else if (is.character(class)) {
     if (!isS4(act$val)) {
       fail(sprintf("%s is not an S4 object", act$lab))
+    } else {
+      expect(
+        methods::is(act$val, class),
+        sprintf("%s inherits from %s not %s.", act$lab, act_val_lab, exp_lab)
+      )
     }
-    expect(
-      methods::is(act$val, class),
-      sprintf("%s inherits from %s not %s.", act$lab, act_val_lab, exp_lab)
-    )
   } else {
     abort("`class` must be a NA or a character vector")
   }

--- a/R/expect-known.R
+++ b/R/expect-known.R
@@ -100,7 +100,7 @@ compare_file <- function(path, lines, ..., update = TRUE, info = NULL) {
       encodeString(path, quote = "'"), paste0(comp, collapse = "\n\n")
     ),
     info = info,
-    trace_env = caller_env(1)
+    trace_env = caller_env()
   )
 }
 

--- a/R/expect-known.R
+++ b/R/expect-known.R
@@ -99,7 +99,8 @@ compare_file <- function(path, lines, ..., update = TRUE, info = NULL) {
       "Results have changed from known value recorded in %s.\n\n%s",
       encodeString(path, quote = "'"), paste0(comp, collapse = "\n\n")
     ),
-    info = info
+    info = info,
+    trace = test_trace(2)
   )
 }
 

--- a/R/expect-known.R
+++ b/R/expect-known.R
@@ -100,7 +100,7 @@ compare_file <- function(path, lines, ..., update = TRUE, info = NULL) {
       encodeString(path, quote = "'"), paste0(comp, collapse = "\n\n")
     ),
     info = info,
-    trace = test_trace(2)
+    trace_env = caller_env(1)
   )
 }
 

--- a/R/expect-that.R
+++ b/R/expect-that.R
@@ -50,7 +50,7 @@ expect_that <- function(object, condition, info = NULL, label = NULL) {
 #' test_that("this test fails", fail())
 #' test_that("this test succeeds", succeed())
 #' }
-fail <- function(message = "Failure has been forced", info = NULL, trace_env = caller_env(1)) {
+fail <- function(message = "Failure has been forced", info = NULL, trace_env = caller_env()) {
   expect(FALSE, message, info = info, trace_env = trace_env)
 }
 

--- a/R/expect-that.R
+++ b/R/expect-that.R
@@ -50,8 +50,8 @@ expect_that <- function(object, condition, info = NULL, label = NULL) {
 #' test_that("this test fails", fail())
 #' test_that("this test succeeds", succeed())
 #' }
-fail <- function(message = "Failure has been forced", info = NULL, trace = NULL) {
-  expect(FALSE, message, info = info, trace = trace %||% test_trace(2))
+fail <- function(message = "Failure has been forced", info = NULL, trace_env = caller_env(1)) {
+  expect(FALSE, message, info = info, trace_env = trace_env)
 }
 
 #' @rdname fail

--- a/R/expect-that.R
+++ b/R/expect-that.R
@@ -50,10 +50,9 @@ expect_that <- function(object, condition, info = NULL, label = NULL) {
 #' test_that("this test fails", fail())
 #' test_that("this test succeeds", succeed())
 #' }
-fail <- function(message = "Failure has been forced", info = NULL) {
-  expect(FALSE, message, info = info)
+fail <- function(message = "Failure has been forced", info = NULL, trace = NULL) {
+  expect(FALSE, message, info = info, trace = trace %||% test_trace(2))
 }
-
 
 #' @rdname fail
 #' @export

--- a/R/expect-vector.R
+++ b/R/expect-vector.R
@@ -19,12 +19,13 @@
 expect_vector <- function(object, ptype = NULL, size = NULL) {
   act <- quasi_label(enquo(object), arg = "object")
 
+  message <- NULL
   tryCatch(
     vctrs::vec_assert(act$val, ptype = ptype, size = size, arg = act$lab),
     vctrs_error_assert = function(e) {
-      expect(FALSE, e$message)
+      message <<- e$message
     }
   )
 
-  expect(TRUE, "success")
+  expect(is.null(message), message)
 }

--- a/R/expectation.R
+++ b/R/expectation.R
@@ -48,8 +48,28 @@ expect <- function(ok, failure_message, info = NULL, srcref = NULL, trace = NULL
     }
   }
 
+  if (ok) {
+    # Never capture trace back for successes
+    trace <- NULL
+  } else {
+    # Always capture trace if for failures; but only show if there's at least
+    # one function apart from the expectation
+    trace <- trace %||% test_trace(2)
+    if (trace_length(trace) <= 1) {
+      trace <- NULL
+    }
+  }
+
   exp <- expectation(type, message, srcref = srcref, trace = trace)
   exp_signal(exp)
+}
+
+
+test_trace <- function(parents = 1) {
+  trace_back(
+    top = getOption("testthat_topenv"),
+    bottom = parents + 1
+  )
 }
 
 #' Construct an expectation object

--- a/R/expectation.R
+++ b/R/expectation.R
@@ -39,7 +39,7 @@ expect <- function(ok, failure_message,
                    info = NULL,
                    srcref = NULL,
                    trace = NULL,
-                   trace_env = caller_env(1)) {
+                   trace_env = caller_env()) {
   type <- if (ok) "success" else "failure"
 
   # Preserve existing API which appear to be used in package test code

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -229,7 +229,7 @@ expect_snapshot_helper <- function(lab, val,
       paste0(comp, collapse = "\n\n"),
       hint
     ),
-    trace = test_trace(2)
+    trace_env = caller_env(1)
   )
 }
 

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -229,7 +229,7 @@ expect_snapshot_helper <- function(lab, val,
       paste0(comp, collapse = "\n\n"),
       hint
     ),
-    trace_env = caller_env(1)
+    trace_env = caller_env()
   )
 }
 

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -228,7 +228,8 @@ expect_snapshot_helper <- function(lab, val,
       lab,
       paste0(comp, collapse = "\n\n"),
       hint
-    )
+    ),
+    trace = test_trace(2)
   )
 }
 

--- a/R/source.R
+++ b/R/source.R
@@ -31,6 +31,8 @@ source_file <- function(path, env = test_env(), chdir = TRUE,
     old_dir <- setwd(dirname(path))
     on.exit(setwd(old_dir), add = TRUE)
   }
+
+  withr::local_options(testthat_topenv = env)
   if (wrap) {
     invisible(test_code(NULL, exprs, env))
   } else {

--- a/R/test-that.R
+++ b/R/test-that.R
@@ -186,6 +186,8 @@ test_code <- function(test, code, env = test_env(), reporter = get_reporter(), s
   old <- options(rlang_trace_top_env = test_env)[[1]]
   on.exit(options(rlang_trace_top_env = old), add = TRUE)
 
+  withr::local_options(testthat_topenv = test_env)
+
   tryCatch(
     withCallingHandlers(
       {

--- a/man/expect.Rd
+++ b/man/expect.Rd
@@ -10,7 +10,7 @@ expect(
   info = NULL,
   srcref = NULL,
   trace = NULL,
-  trace_env = caller_env(1)
+  trace_env = caller_env()
 )
 }
 \arguments{

--- a/man/expect.Rd
+++ b/man/expect.Rd
@@ -4,7 +4,14 @@
 \alias{expect}
 \title{The building block of all \code{expect_} functions}
 \usage{
-expect(ok, failure_message, info = NULL, srcref = NULL, trace = NULL)
+expect(
+  ok,
+  failure_message,
+  info = NULL,
+  srcref = NULL,
+  trace = NULL,
+  trace_env = caller_env(1)
+)
 }
 \arguments{
 \item{ok}{\code{TRUE} or \code{FALSE} indicating if the expectation was successful.}
@@ -19,6 +26,11 @@ supplied when you need to forward a srcref captured elsewhere.}
 
 \item{trace}{An optional backtrace created by \code{\link[rlang:trace_back]{rlang::trace_back()}}.
 When supplied, the expectation is displayed with the backtrace.}
+
+\item{trace_env}{If \code{is.null(trace)}, this is used to automatically
+generate a traceback running from \code{test_code()}/\code{test_file()} to
+\code{trace_env}. You'll generally only need to set this if you're wrapping
+an expectation inside another function.}
 }
 \value{
 An expectation object. Signals the expectation condition

--- a/man/fail.Rd
+++ b/man/fail.Rd
@@ -5,7 +5,11 @@
 \alias{succeed}
 \title{Default expectations that always succeed or fail.}
 \usage{
-fail(message = "Failure has been forced", info = NULL, trace = NULL)
+fail(
+  message = "Failure has been forced",
+  info = NULL,
+  trace_env = caller_env(1)
+)
 
 succeed(message = "Success has been forced", info = NULL)
 }
@@ -15,8 +19,10 @@ succeed(message = "Success has been forced", info = NULL)
 \item{info}{Character vector continuing additional information. Included
 for backward compatibility only and new expectations should not use it.}
 
-\item{trace}{An optional backtrace created by \code{\link[rlang:trace_back]{rlang::trace_back()}}.
-When supplied, the expectation is displayed with the backtrace.}
+\item{trace_env}{If \code{is.null(trace)}, this is used to automatically
+generate a traceback running from \code{test_code()}/\code{test_file()} to
+\code{trace_env}. You'll generally only need to set this if you're wrapping
+an expectation inside another function.}
 }
 \description{
 These allow you to manually trigger success or failure. Failure is

--- a/man/fail.Rd
+++ b/man/fail.Rd
@@ -5,7 +5,7 @@
 \alias{succeed}
 \title{Default expectations that always succeed or fail.}
 \usage{
-fail(message = "Failure has been forced", info = NULL)
+fail(message = "Failure has been forced", info = NULL, trace = NULL)
 
 succeed(message = "Success has been forced", info = NULL)
 }
@@ -14,6 +14,9 @@ succeed(message = "Success has been forced", info = NULL)
 
 \item{info}{Character vector continuing additional information. Included
 for backward compatibility only and new expectations should not use it.}
+
+\item{trace}{An optional backtrace created by \code{\link[rlang:trace_back]{rlang::trace_back()}}.
+When supplied, the expectation is displayed with the backtrace.}
 }
 \description{
 These allow you to manually trigger success or failure. Failure is

--- a/man/fail.Rd
+++ b/man/fail.Rd
@@ -8,7 +8,7 @@
 fail(
   message = "Failure has been forced",
   info = NULL,
-  trace_env = caller_env(1)
+  trace_env = caller_env()
 )
 
 succeed(message = "Success has been forced", info = NULL)

--- a/tests/testthat/_snaps/reporter-check.md
+++ b/tests/testthat/_snaps/reporter-check.md
@@ -21,6 +21,10 @@
     
     `actual`:   FALSE
     `expected`: TRUE 
+    Backtrace:
+        x
+     1. \-f() reporters/tests.R:17:2
+     2.   \-testthat::expect_true(FALSE) reporters/tests.R:16:7
     -- Error (tests.R:23:3): Error:1 -----------------------------------------------
     Error: stop
     -- Error (tests.R:31:3): errors get tracebacks ---------------------------------
@@ -68,6 +72,10 @@
     
     `actual`:   FALSE
     `expected`: TRUE 
+    Backtrace:
+        x
+     1. \-f() reporters/tests.R:17:2
+     2.   \-testthat::expect_true(FALSE) reporters/tests.R:16:7
     -- Error (tests.R:23:3): Error:1 -----------------------------------------------
     Error: stop
     -- Error (tests.R:31:3): errors get tracebacks ---------------------------------

--- a/tests/testthat/_snaps/reporter-junit.md
+++ b/tests/testthat/_snaps/reporter-junit.md
@@ -16,7 +16,10 @@
           <failure type="failure" message="FALSE is not TRUE (tests.R:17:3)">FALSE is not TRUE
     
     `actual`:   FALSE
-    `expected`: TRUE </failure>
+    `expected`: TRUE 
+    Backtrace:
+     1. f()
+     2. testthat::expect_true(FALSE)</failure>
         </testcase>
       </testsuite>
       <testsuite name="Errors" timestamp="1999:12:31 23:59:59" hostname="nodename" tests="2" skipped="0" failures="0" errors="2" time="0">

--- a/tests/testthat/_snaps/reporter-progress.md
+++ b/tests/testthat/_snaps/reporter-progress.md
@@ -163,7 +163,9 @@
     | |   0 6 1   | reporters/backtraces                                            
     / |   1 6 1   | reporters/backtraces                                            
     - |   1 7 1   | reporters/backtraces                                            
-    x |   1 7 1   | reporters/backtraces
+    \ |   1 8 1   | reporters/backtraces                                            
+    | |   1 9 1   | reporters/backtraces                                            
+    x |   1 9 1   | reporters/backtraces
     --------------------------------------------------------------------------------
     Error (backtraces.R:6:3): errors thrown at block level are entraced
     Error: foo
@@ -233,10 +235,32 @@
      24. f(x - 1) reporters/backtraces.R:56:4
      25. f(x - 1) reporters/backtraces.R:56:4
      26. f(x - 1) reporters/backtraces.R:56:4
+    
+    Failure (backtraces.R:66:1): (code run outside of `test_that()`)
+    FALSE is not TRUE
+    
+    `actual`:   FALSE
+    `expected`: TRUE 
+    Backtrace:
+     1. f() reporters/backtraces.R:66:0
+     2. g() reporters/backtraces.R:62:5
+     3. h() reporters/backtraces.R:63:5
+     4. testthat::expect_true(FALSE) reporters/backtraces.R:64:5
+    
+    Failure (backtraces.R:69:3): nested expectations get backtraces
+    FALSE is not TRUE
+    
+    `actual`:   FALSE
+    `expected`: TRUE 
+    Backtrace:
+     1. f() reporters/backtraces.R:69:2
+     2. g() reporters/backtraces.R:62:5
+     3. h() reporters/backtraces.R:63:5
+     4. testthat::expect_true(FALSE) reporters/backtraces.R:64:5
     --------------------------------------------------------------------------------
     
     == Results =====================================================================
-    [ FAIL 7 | WARN 1 | SKIP 0 | PASS 1 ]
+    [ FAIL 9 | WARN 1 | SKIP 0 | PASS 1 ]
     
     I believe in you!
 
@@ -263,6 +287,9 @@
     
     `actual`:   FALSE
     `expected`: TRUE 
+    Backtrace:
+     1. f()
+     2. testthat::expect_true(FALSE)
     
     
     [ FAIL 2 | WARN 0 | SKIP 0 | PASS 1 ]

--- a/tests/testthat/_snaps/reporter-stop.md
+++ b/tests/testthat/_snaps/reporter-stop.md
@@ -12,6 +12,9 @@
     
     `actual`:   FALSE
     `expected`: TRUE 
+    Backtrace:
+     1. f()
+     2. testthat::expect_true(FALSE)
     
     -- Error (tests.R:23:3): Error:1 -----------------------------------------------
     Error: stop

--- a/tests/testthat/_snaps/reporter-summary.md
+++ b/tests/testthat/_snaps/reporter-summary.md
@@ -27,6 +27,9 @@
     
     `actual`:   FALSE
     `expected`: TRUE 
+    Backtrace:
+     1. f() reporters/tests.R:17:2
+     2. testthat::expect_true(FALSE) reporters/tests.R:16:7
     
     -- 3. Error (tests.R:23:3): Error:1 --------------------------------------------
     Error: stop
@@ -69,6 +72,9 @@
     
     `actual`:   FALSE
     `expected`: TRUE 
+    Backtrace:
+     1. f() reporters/tests.R:17:2
+     2. testthat::expect_true(FALSE) reporters/tests.R:16:7
     
     -- 3. Error (tests.R:23:3): Error:1 --------------------------------------------
     Error: stop
@@ -111,6 +117,9 @@
     
     `actual`:   FALSE
     `expected`: TRUE 
+    Backtrace:
+     1. f() reporters/tests.R:17:2
+     2. testthat::expect_true(FALSE) reporters/tests.R:16:7
       ... and 2 more
     
     

--- a/tests/testthat/_snaps/reporter-tap.md
+++ b/tests/testthat/_snaps/reporter-tap.md
@@ -14,6 +14,9 @@
       
       `actual`:   FALSE
       `expected`: TRUE 
+      Backtrace:
+       1. f() reporters/tests.R:17:2
+       2. testthat::expect_true(FALSE) reporters/tests.R:16:7
     # Context Errors
     not ok 4 Error:1
       Error: stop

--- a/tests/testthat/_snaps/reporter-teamcity.md
+++ b/tests/testthat/_snaps/reporter-teamcity.md
@@ -18,7 +18,7 @@
     
     ##teamcity[testSuiteStarted name='Failure:2a']
     ##teamcity[testStarted name='expectation 1']
-    ##teamcity[testFailed name='expectation 1' message='FALSE is not TRUE' details='|n`actual`:   FALSE|n`expected`: TRUE ']
+    ##teamcity[testFailed name='expectation 1' message='FALSE is not TRUE' details='|n`actual`:   FALSE|n`expected`: TRUE |nBacktrace:|n 1. f()|n 2. testthat::expect_true(FALSE)']
     ##teamcity[testFinished name='expectation 1']
     ##teamcity[testSuiteFinished name='Failure:2a']
     

--- a/tests/testthat/reporters/backtraces.R
+++ b/tests/testthat/reporters/backtraces.R
@@ -58,3 +58,13 @@ test_that("deep stacks are trimmed", {
   f(25)
 })
 
+# Expectations ----------------------------------------------------------------
+f <- function() g()
+g <- function() h()
+h <- function() expect_true(FALSE)
+
+f()
+
+test_that("nested expectations get backtraces", {
+  f()
+})


### PR DESCRIPTION
Fixes #1307

@lionel- could you please double check my reasoning here? The basic idea is to capture the "topenv" in `test_code()` and `source_file()` (as a fallback for expectations not nested inside `test_that()` blocks) and use that as the `top` argument to `trace_back()`. I then set `bottom` so that the `expect_*` call is at the bottom of the stack (this mostly happens in `expect()`, but I also handled all internal wrappers to avoid exposing implementation details). I then only show the back trace if the expectation fails, and there's more than one call in the backtrace (since the header also gives a location).