### PR TITLE
Fix regexp pattern in grepl (#1375)

### DIFF
--- a/R/snapshot-serialize.R
+++ b/R/snapshot-serialize.R
@@ -16,7 +16,7 @@ snap_from_md <- function(lines) {
   names(tests) <- gsub("^# ", "", lines[h2])
 
   split_tests <- function(lines) {
-    sep <- grepl("^-{3, }", lines)
+    sep <- grepl("^-{3,}", lines)
     case_group <- cumsum(sep)
 
     # Remove first line and last line, separator, line above and line below


### PR DESCRIPTION
Fixes #1375 

This fixes the regexp pattern that is wrongly interpreted by GNU-R. Now the pattern is compatible with PCRE.