### PR TITLE
Reset snapshots on error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # testthat (development version)
 
+* `expect_snapshot()` no longer deletes snapshots when an unexpected
+  error occurs.
+
 * Condition expectations now consistently return the expected
   condition instead of the return value (#1371).
 

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -64,7 +64,11 @@ expect_snapshot <- function(x, cran = FALSE, error = FALSE) {
   # Use expect_error() machinery to confirm that error is as expected
   msg <- compare_condition_3e("error", state$error, quo_label(x), error)
   if (!is.null(msg)) {
-    expect(FALSE, msg, trace = state$error[["trace"]])
+    if (error) {
+      expect(FALSE, msg, trace = state$error[["trace"]])
+    } else {
+      exp_signal(expectation("error", msg, state$error[["trace"]]))
+    }
     return()
   }
 

--- a/tests/testthat/test-snapshot-reporter.R
+++ b/tests/testthat/test-snapshot-reporter.R
@@ -82,3 +82,25 @@ test_that("errors in test doesn't change snapshot", {
   )
   snapper$end_file()
 })
+
+test_that("skips and unexpected errors reset snapshots", {
+  regenerate <- FALSE
+
+  if (regenerate) {
+    withr::local_envvar(c(TESTTHAT_REGENERATE_SNAPS = "true"))
+  }
+
+  catch_cnd(
+    test_file(
+      test_path("test-snapshot", "test-snapshot.R"),
+      reporter = NULL
+    )
+  )
+
+  path <- "test-snapshot/_snaps/snapshot.md"
+  stopifnot(file.exists(path))
+
+  snaps <- snap_from_md(read_lines(path))
+  titles <- c("errors reset snapshots", "skips reset snapshots")
+  expect_true(all(titles %in% names(snaps)))
+})

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -26,7 +26,7 @@ test_that("multiple outputs of same type are collapsed", {
 })
 
 test_that("always checks error status", {
-  expect_failure(expect_snapshot(stop("!"), error = FALSE))
+  expect_error(expect_snapshot(stop("!"), error = FALSE))
   expect_failure(expect_snapshot(print("!"), error = TRUE))
 })
 

--- a/tests/testthat/test-snapshot/_snaps/snapshot.md
+++ b/tests/testthat/test-snapshot/_snaps/snapshot.md
@@ -1,0 +1,14 @@
+# errors reset snapshots
+
+    Code
+      print(1)
+    Output
+      [1] 1
+
+# skips reset snapshots
+
+    Code
+      print(1)
+    Output
+      [1] 1
+

--- a/tests/testthat/test-snapshot/test-snapshot.R
+++ b/tests/testthat/test-snapshot/test-snapshot.R
@@ -1,0 +1,15 @@
+test_that("errors reset snapshots", {
+  if (nzchar(Sys.getenv("TESTTHAT_REGENERATE_SNAPS"))) {
+    expect_snapshot(print(1))
+  } else {
+    expect_snapshot(stop("failing"))
+  }
+})
+
+test_that("skips reset snapshots", {
+  if (nzchar(Sys.getenv("TESTTHAT_REGENERATE_SNAPS"))) {
+    expect_snapshot(print(1))
+  } else {
+    expect_snapshot(skip("skipping"))
+  }
+})


### PR DESCRIPTION
The snapshot reporter normally preserves snapshots when a skip or unexpected error occurs. However, `expect_snapshot()` currently signals a failure rather than an error, causing snapshots to be deleted. This PR fixes that by signalling an error instead of a failure.

To test `expect_snapshot()` itself (instead of testing a local snapshotter via its methods) I have added a new directory of test files.