### PR TITLE
Restore breaking change for condition expectations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,35 @@
 # testthat (development version)
 
 * Condition expectations now consistently return the expected
-  condition instead of the return value (#1371).
+  condition instead of the return value (#1371). Previously, they
+  would only return the condition if the return value was `NULL`,
+  leading to inconsistent behaviour.
+  
+  This is a breaking change (it only affects edition 3). Where you
+  could previously do:
+  
+  ```
+  expect_equal(expect_warning(f(), "warning"), "value")
+  ```
+  
+  You must now use condition expectations on the outside:
+  
+  ```
+  expect_warning(expect_equal(f(), "value"), "warning")
+  
+  # Equivalently, save the value before inspection
+  expect_warning(value <- f(), "warning")
+  expect_equal(value, "value")
+  
+  # If you use `=` instead of `<-` be sure to disambiguate
+  # assignment and argument passing with braces
+  expect_warning({ value = f() }, "warning")
+  expect_equal(value, "value")
+  ```
+  
+  This breaking change makes testthat more consistent. It also makes
+  it possible to inspect both the value and the warning, which would
+  require additional tools otherwise.
 
 # testthat 3.0.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # testthat (development version)
 
+* Condition expectations now consistently return the expected
+  condition instead of the return value (#1371).
+
 # testthat 3.0.3
 
 * `expect_snapshot_file()` gains a `compare` argument (#1378,

--- a/R/expect-condition.R
+++ b/R/expect-condition.R
@@ -235,7 +235,9 @@ expect_condition_matching <- function(base_class,
   # `$.Throwable` from the rJava package throws with unknown fields
   expect(is.null(msg), msg, info = info, trace = act$cap[["trace"]])
 
-  invisible(act$val %||% act$cap)
+  # If a condition was expected, return it. Otherwise return the value
+  # of the expression.
+  invisible(if (expected) act$cap else act$val)
 }
 
 # -------------------------------------------------------------------------

--- a/tests/testthat/test-expect-condition.R
+++ b/tests/testthat/test-expect-condition.R
@@ -132,6 +132,28 @@ test_that("only matching condition is captured, others bubble up", {
   expect_error(expect_condition(f2(), "Hi"), "Bye")
 })
 
+test_that("cnd expectations consistently return condition (#1371)", {
+  f <- function(out, action) {
+    action
+    out
+  }
+
+  expect_s3_class(expect_message(f(NULL, message(""))), "simpleMessage")
+  expect_s3_class(expect_warning(f(NULL, warning(""))), "simpleWarning")
+  expect_s3_class(expect_error(f(NULL, stop(""))), "simpleError")
+
+  # Used to behave differently with non-`NULL` values
+  expect_s3_class(expect_message(f("return value", message(""))), "simpleMessage")
+  expect_s3_class(expect_warning(f("return value", warning(""))), "simpleWarning")
+  expect_s3_class(expect_error(f("return value", stop(""))), "simpleError")
+
+  # If there is no condition expected we return the value
+  expect_equal(expect_message(f("return value", NULL), regexp = NA), "return value")
+  expect_equal(expect_warning(f("return value", NULL), regexp = NA), "return value")
+  expect_equal(expect_error(f("return value", NULL), regexp = NA), "return value")
+})
+
+
 # second edition ----------------------------------------------------------
 
 test_that("other conditions are swallowed", {


### PR DESCRIPTION
To merge after the 3.0.3 release.

The NEWS item now goes over more details about the breaking change, its motivation, and how to fix it.