### PR TITLE
Fix failing `expect_condition()` inside snapshots

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # testthat (development version)
 
+* Fixed an issue that caused errors and early termination of tests on
+  R <= 3.6 when a failing condition expectation was signalled inside a
+  snapshot.
+
 * Condition expectations now consistently return the expected
   condition instead of the return value (#1371). Previously, they
   would only return the condition if the return value was `NULL`,

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -67,7 +67,7 @@ expect_snapshot <- function(x, cran = FALSE, error = FALSE) {
     if (error) {
       expect(FALSE, msg, trace = state$error[["trace"]])
     } else {
-      exp_signal(expectation("error", msg, state$error[["trace"]]))
+      exp_signal(expectation("error", msg, trace = state$error[["trace"]]))
     }
     return()
   }

--- a/tests/testthat/test-snapshot-reporter.R
+++ b/tests/testthat/test-snapshot-reporter.R
@@ -104,3 +104,12 @@ test_that("skips and unexpected errors reset snapshots", {
   titles <- c("errors reset snapshots", "skips reset snapshots")
   expect_true(all(titles %in% names(snaps)))
 })
+
+test_that("`expect_error()` can fail inside `expect_snapshot()`", {
+  out <- test_file(
+    test_path("test-snapshot", "test-expect-condition.R"),
+    reporter = NULL
+  )
+  err <- out[[1]]$results[[1]]
+  expect_match(err$message, "did not throw the expected error")
+})

--- a/tests/testthat/test-snapshot/test-expect-condition.R
+++ b/tests/testthat/test-snapshot/test-expect-condition.R
@@ -1,0 +1,3 @@
+test_that("can use failing condition expectation inside `expect_snapshot()`", {
+  expect_snapshot(expect_error(NULL))
+})


### PR DESCRIPTION
Follow-up to #1396 where I mistakenly stored backtraces as `srcref` attribute, causing errors on R <= 3.6 when a failing condition expectation is signalled inside a snapshot:

```r
test_that("foo", {
  expect_snapshot(expect_error(NULL))
})
#> Error in basename(filename) : a character vector argument expected
```