### PR TITLE
Fix partial match `n_skip_`

### DIFF
--- a/R/reporter-progress.R
+++ b/R/reporter-progress.R
@@ -383,7 +383,7 @@ ParallelProgressReporter <- R6::R6Class("ParallelProgressReporter",
         self$files[[file]] <- list(
           issues = Stack$new(),
           n_fail = 0L,
-          n_skip_ = 0L,
+          n_skip = 0L,
           n_warn = 0L,
           n_ok = 0L,
           name = context_name(file),
@@ -439,7 +439,7 @@ ParallelProgressReporter <- R6::R6Class("ParallelProgressReporter",
         self$files[[file]]$issues$push(result)
       } else if (expectation_skip(result)) {
         self$n_skip <- self$n_skip + 1
-        self$files[[file]]$n_skip_ <- self$files[[file]]$n_skip_ + 1L
+        self$files[[file]]$n_skip <- self$files[[file]]$n_skip + 1L
         if (self$verbose_skips) {
           self$files[[file]]$issues$push(result)
         }


### PR DESCRIPTION
Relates to #1316.

Running tests in parallel produced a warning about partial matches with `n_skip_`. After checking the code I'm pretty sure it should be `n_skip` instead of `n_skip_`.

1. `n_fail`, `n_warn`, and `n_ok` without trailing underscore
2. `show_status()` accesses the field `n_skip` (which causes the partial match warning)
3. No more issues for me after changing to `n_skip`

```r
# ParallelProgressReporter
status_data = function() {
  self$files[[self$file_name]]
}

start_file = function(file)  {
  if (! file %in% names(self$files)) {
    self$files[[file]] <- list(
      issues = Stack$new(),
      n_fail = 0L,
      n_skip_ = 0L,
      n_warn = 0L,
      n_ok = 0L,
      name = context_name(file),
      start_time = proc.time()
    )
  }
  self$file_name <- file
},

# ProgressReporter
status_data = function() {
  list(
    n = self$ctxt_n,
    n_ok = self$ctxt_n_ok,
    n_fail = self$ctxt_n_fail,
    n_warn = self$ctxt_n_warn,
    n_skip = self$ctxt_n_skip,
    name = self$ctxt_name
  )
}


show_status = function(complete = FALSE, time = 0, pad = FALSE) {
  data <- self$status_data()
  
  # ...
  
  message <- paste0(
    status, " | ", sprintf("%3d", data$n_ok), " ",
    # ...
    col_format(data$n_skip, "skip"), " | "
  )
  
  # ...
}
```