### PR TITLE
Tweak progress reporter colours/order

### DIFF
--- a/R/reporter-check.R
+++ b/R/reporter-check.R
@@ -73,13 +73,17 @@ CheckReporter <- R6::R6Class("CheckReporter",
 )
 
 summary_line <- function(n_fail, n_warn, n_skip, n_pass) {
+  colourise_if <- function(text, colour, cond) {
+    if (cond) colourise(text, colour) else text
+  }
+
   # Ordered from most important to least important
   paste0(
     "[ ",
-    colourise("FAIL", "failure"), " ", n_fail, " | ",
-    colourise("WARN", "warn"),    " ", n_warn, " | ",
-    colourise("SKIP", "skip"),    " ", n_skip, " | ",
-    colourise("PASS", "success"), " ", n_pass,
+    colourise_if("FAIL", "failure", n_fail > 0), " ", n_fail, " | ",
+    colourise_if("WARN", "warn", n_warn > 0),    " ", n_warn, " | ",
+    colourise_if("SKIP", "skip", n_skip > 0),    " ", n_skip, " | ",
+    colourise_if("PASS", "success", n_fail == 0), " ", n_pass,
     " ]"
   )
 }

--- a/R/reporter-progress.R
+++ b/R/reporter-progress.R
@@ -159,7 +159,7 @@ ProgressReporter <- R6::R6Class("ProgressReporter",
       if (complete && time > self$min_time) {
         message <- paste0(
           message,
-          cli::col_cyan(sprintf(" [%.1f s]", time))
+          cli::col_grey(sprintf(" [%.1fs]", time))
         )
       }
 

--- a/R/reporter-progress.R
+++ b/R/reporter-progress.R
@@ -98,11 +98,12 @@ ProgressReporter <- R6::R6Class("ProgressReporter",
 
     show_header = function() {
       self$cat_line(
-        cli::symbol$tick, " |  OK ",
+        colourise(cli::symbol$tick, "success"), " | ",
         colourise("F", "failure"), " ",
         colourise("W", "warning"), " ",
-        colourise("S", "skip"), " | ",
-        "Context"
+        colourise("S", "skip"), " ",
+        colourise(" OK", "success"),
+        " | ", "Context"
       )
     },
 
@@ -142,16 +143,17 @@ ProgressReporter <- R6::R6Class("ProgressReporter",
         if (n == 0) {
           " "
         } else {
-          n
+          colourise(n, type)
         }
       }
 
       message <- paste0(
-        status, " | ", sprintf("%3d", data$n_ok), " ",
+        status, " | ",
         col_format(data$n_fail, "fail"), " ",
         col_format(data$n_warn, "warn"), " ",
-        col_format(data$n_skip, "skip"), " | ",
-        data$name
+        col_format(data$n_skip, "skip"), " ",
+        sprintf("%3d", data$n_ok),
+        " | ", data$name
       )
 
       if (complete && time > self$min_time) {

--- a/tests/testthat/_snaps/reporter-progress.md
+++ b/tests/testthat/_snaps/reporter-progress.md
@@ -1,10 +1,10 @@
 # captures error before first test
 
-    v |  OK F W S | Context
+    v | F W S  OK | Context
     
-    / |   0       | reporters/error-setup                                           
-    - |   0 1     | reporters/error-setup                                           
-    x |   0 1     | reporters/error-setup
+    / |         0 | reporters/error-setup                                           
+    - | 1       0 | reporters/error-setup                                           
+    x | 1       0 | reporters/error-setup
     --------------------------------------------------------------------------------
     Error (error-setup.R:6:1): (code run outside of `test_that()`)
     Error: !
@@ -22,12 +22,12 @@
 
 # gracefully handles multiple contexts
 
-    v |  OK F W S | Context
+    v | F W S  OK | Context
     
-    / |   0       | reporters/context                                               
-    / |   0       | my context                                                      
-    - |   1       | my context                                                      
-    v |   1       | my context
+    / |         0 | reporters/context                                               
+    / |         0 | my context                                                      
+    - |         1 | my context                                                      
+    v |         1 | my context
     
     == Results =====================================================================
     [ FAIL 0 | WARN 0 | SKIP 0 | PASS 1 ]
@@ -36,19 +36,19 @@
 
 # fails after max_fail tests
 
-    v |  OK F W S | Context
+    v | F W S  OK | Context
     
-    / |   0       | reporters/fail-many                                             
-    - |   0 1     | reporters/fail-many                                             
-    \ |   0 2     | reporters/fail-many                                             
-    | |   0 3     | reporters/fail-many                                             
-    / |   0 4     | reporters/fail-many                                             
-    - |   0 5     | reporters/fail-many                                             
-    \ |   0 6     | reporters/fail-many                                             
-    | |   0 7     | reporters/fail-many                                             
-    / |   0 8     | reporters/fail-many                                             
-    - |   0 9     | reporters/fail-many                                             
-    x |   0 10     | reporters/fail-many
+    / |         0 | reporters/fail-many                                             
+    - | 1       0 | reporters/fail-many                                             
+    \ | 2       0 | reporters/fail-many                                             
+    | | 3       0 | reporters/fail-many                                             
+    / | 4       0 | reporters/fail-many                                             
+    - | 5       0 | reporters/fail-many                                             
+    \ | 6       0 | reporters/fail-many                                             
+    | | 7       0 | reporters/fail-many                                             
+    / | 8       0 | reporters/fail-many                                             
+    - | 9       0 | reporters/fail-many                                             
+    x | 10       0 | reporters/fail-many
     --------------------------------------------------------------------------------
     Failure (fail-many.R:3:5): Example
     FALSE is not TRUE
@@ -121,17 +121,17 @@
 
 # can fully suppress incremental updates
 
-    v |  OK F W S | Context
+    v | F W S  OK | Context
     
-    / |   0       | reporters/successes                                             
-    - |   1       | reporters/successes                                             
-    \ |   2       | reporters/successes                                             
-    | |   3       | reporters/successes                                             
-    / |   4       | reporters/successes                                             
-    - |   5       | reporters/successes                                             
-    \ |   6       | reporters/successes                                             
-    | |   7       | reporters/successes                                             
-    v |   7       | reporters/successes
+    / |         0 | reporters/successes                                             
+    - |         1 | reporters/successes                                             
+    \ |         2 | reporters/successes                                             
+    | |         3 | reporters/successes                                             
+    / |         4 | reporters/successes                                             
+    - |         5 | reporters/successes                                             
+    \ |         6 | reporters/successes                                             
+    | |         7 | reporters/successes                                             
+    v |         7 | reporters/successes
     
     == Results =====================================================================
     [ FAIL 0 | WARN 0 | SKIP 0 | PASS 7 ]
@@ -140,9 +140,9 @@
 
 ---
 
-    v |  OK F W S | Context
+    v | F W S  OK | Context
     
-    v |   7       | reporters/successes
+    v |         7 | reporters/successes
     
     == Results =====================================================================
     [ FAIL 0 | WARN 0 | SKIP 0 | PASS 7 ]
@@ -151,21 +151,21 @@
 
 # reports backtraces
 
-    v |  OK F W S | Context
+    v | F W S  OK | Context
     
-    / |   0       | reporters/backtraces                                            
-    - |   0 1     | reporters/backtraces                                            
-    \ |   0 2     | reporters/backtraces                                            
-    | |   0 3     | reporters/backtraces                                            
-    / |   0 4     | reporters/backtraces                                            
-    - |   0 5     | reporters/backtraces                                            
-    \ |   0 6     | reporters/backtraces                                            
-    | |   0 6 1   | reporters/backtraces                                            
-    / |   1 6 1   | reporters/backtraces                                            
-    - |   1 7 1   | reporters/backtraces                                            
-    \ |   1 8 1   | reporters/backtraces                                            
-    | |   1 9 1   | reporters/backtraces                                            
-    x |   1 9 1   | reporters/backtraces
+    / |         0 | reporters/backtraces                                            
+    - | 1       0 | reporters/backtraces                                            
+    \ | 2       0 | reporters/backtraces                                            
+    | | 3       0 | reporters/backtraces                                            
+    / | 4       0 | reporters/backtraces                                            
+    - | 5       0 | reporters/backtraces                                            
+    \ | 6       0 | reporters/backtraces                                            
+    | | 6 1     0 | reporters/backtraces                                            
+    / | 6 1     1 | reporters/backtraces                                            
+    - | 7 1     1 | reporters/backtraces                                            
+    \ | 8 1     1 | reporters/backtraces                                            
+    | | 9 1     1 | reporters/backtraces                                            
+    x | 9 1     1 | reporters/backtraces
     --------------------------------------------------------------------------------
     Error (backtraces.R:6:3): errors thrown at block level are entraced
     Error: foo


### PR DESCRIPTION
* In final summary, only warn/fail/skip if non-zero and only colour pass if no failures. This draws attention to the most important results.
* Colour per-file fails/warnings/skips to make it easier to see which it is (since the header is often off-screen)
* Match order of per-file results to order of test suite results (i.e. always show failures first and passes last)

Fixes #1382

Example of final summary:
<img width="362" alt="Screenshot 2021-07-08 at 9 03 39 AM" src="https://user-images.githubusercontent.com/4196/124828455-645b6b00-dfcb-11eb-89f1-8ee532f212c9.png">
<img width="381" alt="Screenshot 2021-07-08 at 9 03 03 AM" src="https://user-images.githubusercontent.com/4196/124828401-51489b00-dfcb-11eb-8ce1-1a34dd5ece16.png">

Example of per-file output:
<img width="381" alt="Screenshot 2021-07-08 at 9 04 51 AM" src="https://user-images.githubusercontent.com/4196/124828580-8fde5580-dfcb-11eb-92af-6fc40680270d.png">

@torbjorn how does this look to you? @jennybc, @lionel-, @gaborcsardi any thoughts/comments on this change?