### PR TITLE
Show full error call

### DIFF
--- a/R/expectation.R
+++ b/R/expectation.R
@@ -196,7 +196,7 @@ as.expectation.error <- function(x, srcref = NULL) {
   if (is.null(x$call)) {
     header <- paste0("Error: ")
   } else {
-    header <- paste0("Error in ", summarise_call(x$call), ": ")
+    header <- paste0("Error in `", deparse1(x$call), "`: ")
   }
 
   msg <- paste0(
@@ -207,13 +207,6 @@ as.expectation.error <- function(x, srcref = NULL) {
   expectation("error", msg, srcref, trace = x[["trace"]])
 }
 
-summarise_call <- function(x) {
-  if (env_has(ns_env("rlang"), "format_error_call")) {
-    format_error_call(x)
-  } else {
-    paste0("`", as_label(x[1]), "`")
-  }
-}
 
 is_simple_error <- function(x) {
   class(x)[[1]] %in% c("simpleError", "rlang_error")

--- a/tests/testthat/_snaps/reporter-check.md
+++ b/tests/testthat/_snaps/reporter-check.md
@@ -26,7 +26,7 @@
      1. \-f() reporters/tests.R:17:2
      2.   \-testthat::expect_true(FALSE) reporters/tests.R:16:7
     -- Error (tests.R:23:3): Error:1 -----------------------------------------------
-    Error in `eval()`: stop
+    Error in `eval(code, test_env)`: stop
     -- Error (tests.R:31:3): errors get tracebacks ---------------------------------
     Error in `h()`: !
     Backtrace:
@@ -77,7 +77,7 @@
      1. \-f() reporters/tests.R:17:2
      2.   \-testthat::expect_true(FALSE) reporters/tests.R:16:7
     -- Error (tests.R:23:3): Error:1 -----------------------------------------------
-    Error in `eval()`: stop
+    Error in `eval(code, test_env)`: stop
     -- Error (tests.R:31:3): errors get tracebacks ---------------------------------
     Error in `h()`: !
     Backtrace:

--- a/tests/testthat/_snaps/reporter-junit.md
+++ b/tests/testthat/_snaps/reporter-junit.md
@@ -24,7 +24,7 @@
       </testsuite>
       <testsuite name="Errors" timestamp="1999:12:31 23:59:59" hostname="nodename" tests="2" skipped="0" failures="0" errors="2" time="0">
         <testcase time="0" classname="Errors" name="Error_1">
-          <error type="error" message="Error in `eval()`: stop (tests.R:23:3)">Error in `eval()`: stop</error>
+          <error type="error" message="Error in `eval(code, test_env)`: stop (tests.R:23:3)">Error in `eval(code, test_env)`: stop</error>
         </testcase>
         <testcase time="0" classname="Errors" name="errors_get_tracebacks">
           <error type="error" message="Error in `h()`: ! (tests.R:31:3)">Error in `h()`: !

--- a/tests/testthat/_snaps/reporter-progress.md
+++ b/tests/testthat/_snaps/reporter-progress.md
@@ -213,7 +213,7 @@
      2. bar() reporters/backtraces.R:47:9
     
     Error (backtraces.R:58:3): deep stacks are trimmed
-    Error in `f()`: This is deep
+    Error in `f(x - 1)`: This is deep
     Backtrace:
       1. f(25) reporters/backtraces.R:58:2
       2. f(x - 1) reporters/backtraces.R:56:4
@@ -324,7 +324,7 @@
     [ FAIL 4 | WARN 0 | SKIP 0 | PASS 1 ]
     
     -- Error (tests.R:23:3): Error:1 -----------------------------------------------
-    Error in `eval()`: stop
+    Error in `eval(code, test_env)`: stop
     
     -- Error (tests.R:31:3): errors get tracebacks ---------------------------------
     Error in `h()`: !

--- a/tests/testthat/_snaps/reporter-rstudio.md
+++ b/tests/testthat/_snaps/reporter-rstudio.md
@@ -2,7 +2,7 @@
 
     tests.R:12:3 [failure] Failure:1. FALSE is not TRUE
     tests.R:17:3 [failure] Failure:2a. FALSE is not TRUE
-    tests.R:23:3 [error] Error:1. Error in `eval()`: stop
+    tests.R:23:3 [error] Error:1. Error in `eval(code, test_env)`: stop
     tests.R:31:3 [error] errors get tracebacks. Error in `h()`: !
     tests.R:37:3 [skip] explicit skips are reported. Reason: skip
     tests.R:40:1 [skip] empty tests are implicitly skipped. Reason: empty test

--- a/tests/testthat/_snaps/reporter-stop.md
+++ b/tests/testthat/_snaps/reporter-stop.md
@@ -17,7 +17,7 @@
      2. testthat::expect_true(FALSE)
     
     -- Error (tests.R:23:3): Error:1 -----------------------------------------------
-    Error in `eval()`: stop
+    Error in `eval(code, test_env)`: stop
     
     -- Error (tests.R:31:3): errors get tracebacks ---------------------------------
     Error in `h()`: !

--- a/tests/testthat/_snaps/reporter-summary.md
+++ b/tests/testthat/_snaps/reporter-summary.md
@@ -34,7 +34,7 @@
      2. testthat::expect_true(FALSE) reporters/tests.R:16:7
     
     -- 3. Error (tests.R:23:3): Error:1 --------------------------------------------
-    Error in `eval()`: stop
+    Error in `eval(code, test_env)`: stop
     
     -- 4. Error (tests.R:31:3): errors get tracebacks ------------------------------
     Error in `h()`: !
@@ -81,7 +81,7 @@
      2. testthat::expect_true(FALSE) reporters/tests.R:16:7
     
     -- 3. Error (tests.R:23:3): Error:1 --------------------------------------------
-    Error in `eval()`: stop
+    Error in `eval(code, test_env)`: stop
     
     -- 4. Error (tests.R:31:3): errors get tracebacks ------------------------------
     Error in `h()`: !

--- a/tests/testthat/_snaps/reporter-tap.md
+++ b/tests/testthat/_snaps/reporter-tap.md
@@ -19,7 +19,7 @@
        2. testthat::expect_true(FALSE) reporters/tests.R:16:7
     # Context Errors
     not ok 4 Error:1
-      Error in `eval()`: stop
+      Error in `eval(code, test_env)`: stop
     not ok 5 errors get tracebacks
       Error in `h()`: !
       Backtrace:

--- a/tests/testthat/_snaps/reporter-teamcity.md
+++ b/tests/testthat/_snaps/reporter-teamcity.md
@@ -28,7 +28,7 @@
     ##teamcity[testSuiteStarted name='Errors']
     ##teamcity[testSuiteStarted name='Error:1']
     ##teamcity[testStarted name='expectation 1']
-    ##teamcity[testFailed name='expectation 1' message='Error in `eval()`: stop' details='']
+    ##teamcity[testFailed name='expectation 1' message='Error in `eval(code, test_env)`: stop' details='']
     ##teamcity[testFinished name='expectation 1']
     ##teamcity[testSuiteFinished name='Error:1']
     


### PR DESCRIPTION
Until we can use rlang::error_call()

Fixes #1449