### PR TITLE
Overwrite file snapshots

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,9 @@
   stochastic (e.g. random temporary directory names) from snapshot output 
   (#1345).
 
+* `expect_snapshot_file()` now replaces previous `.new` snapshot if code
+  fails again with a different value.
+
 * `expect_snapshot_value()` now has an explicit `tolerance` argument which 
   uses the testthat default, thus making it more like `expect_equal()` rather 
   than `expect_identical()`. Set it to `NULL` if you want precise comparisons 

--- a/R/snapshot-file.R
+++ b/R/snapshot-file.R
@@ -152,7 +152,7 @@ snapshot_file_equal <- function(snap_test_dir, snap_name, path, file_equal = com
   if (file.exists(cur_path)) {
     eq <- file_equal(cur_path, path)
     if (!eq) {
-      file.copy(path, new_path)
+      file.copy(path, new_path, overwrite = TRUE)
     } else {
       # in case it exists from a previous run
       unlink(new_path)

--- a/tests/testthat/test-snapshot-file.R
+++ b/tests/testthat/test-snapshot-file.R
@@ -70,7 +70,7 @@ test_that("can announce snapshot file", {
 # snapshot_file_equal -----------------------------------------------------
 
 test_that("warns on first creation", {
-  path <- write_tmp_lines(letters[[1]])
+  path <- write_tmp_lines("a")
   withr::defer(unlink(file.path(tempdir(), "test.txt")))
 
   # Warns on first run
@@ -85,10 +85,15 @@ test_that("warns on first creation", {
   expect_false(file.exists(file.path(tempdir(), "test.new.txt")))
 
   # Changed returns FALSE
-  path2 <- write_tmp_lines(letters[[2]])
+  path2 <- write_tmp_lines("b")
   expect_false(snapshot_file_equal(tempdir(), "test.txt", path2))
   expect_true(file.exists(file.path(tempdir(), "test.txt")))
   expect_true(file.exists(file.path(tempdir(), "test.new.txt")))
+
+  # Changing again overwrites
+  path2 <- write_tmp_lines("c")
+  expect_false(snapshot_file_equal(tempdir(), "test.txt", path2))
+  expect_equal(read_lines(file.path(tempdir(), "test.new.txt")), "c")
 
   # Unchanged cleans up
   expect_true(snapshot_file_equal(tempdir(), "test.txt", path))


### PR DESCRIPTION
So that new failures replace old ones

cc @schloerke