### PR TITLE
snapshot_replay(<rlang_error>)

### DIFF
--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -128,6 +128,13 @@ snapshot_replay.condition <- function(x, state, transform = NULL) {
 
   c(snap_header(state, class), snapshot_lines(msg, transform))
 }
+#' @export
+snapshot_replay.rlang_error <- function(x, state, transform = NULL) {
+  state$error <- x
+  msg <- format(x, backtrace = FALSE)
+
+  c(snap_header(state, "Error"), snapshot_lines(msg, transform))
+}
 
 snapshot_lines <- function(x, transform = NULL) {
   x <- split_lines(x)


### PR DESCRIPTION
``` r
library(rlang)
library(testthat)
#> 
#> Attaching package: 'testthat'
#> The following objects are masked from 'package:rlang':
#> 
#>     is_false, is_null, is_true

f <- function() abort("f()")
g <- function() tryCatch(f(), error = function(e) abort("g()", parent = e))

test_that("", {
  local_edition(3)
  
  expect_snapshot(error = TRUE, {
    g()
  })
  
})
#> Can't compare snapshot to reference when testing interactively
#> ℹ Run `devtools::test()` or `testthat::test_file()` to see changes
#> ℹ Current value:
#> Code
#>   g()
#> Error
#>   <error/rlang_error>
#>   Error: 
#>     g()
#>   Caused by error in `f()`: 
#>     f()
#> ── Skip (test-that.R:53:3):  ───────────────────────────────────────────────────
#> Reason: empty test
```

<sup>Created on 2021-10-07 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1.9000)</sup>


