### PR TITLE
dont indent() an empty message

### DIFF
--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -134,7 +134,8 @@ snapshot_lines <- function(x, transform = NULL) {
   if (!is.null(transform)) {
     x <- transform(x)
   }
-  x <- indent(x)
+  # if transform() wiped out the full message, don't indent, #1487
+  if (length(x)) x <- indent(x)
   x
 }
 

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -134,8 +134,7 @@ snapshot_lines <- function(x, transform = NULL) {
   if (!is.null(transform)) {
     x <- transform(x)
   }
-  # if transform() wiped out the full message, don't indent, #1487
-  if (length(x)) x <- indent(x)
+  x <- indent(x)
   x
 }
 
@@ -313,7 +312,8 @@ local_snapshot_dir <- function(snap_names, .env = parent.frame()) {
   path
 }
 
-indent <- function(x) paste0("  ", x)
+# if transform() wiped out the full message, don't indent, #1487
+indent <- function(x) if (length(x)) paste0("  ", x) else x
 
 check_variant <- function(x) {
   if (is.null(x)) {


### PR DESCRIPTION
Fixes #1487 -- `character()` is not passed to `indent()`, so `"  "` won't show up in the output.

I'm not sure this is a complete solution, or if it might have unintended consequences, so I am just filing this simple PR demonstrating a fix for now before attempting to add tests/NEWS.