### PR TITLE
Add support for rlang 1.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,17 @@
   like `!!`.
 
 * Fixed bug in expectations with long inputs that use `::` (#1472).
+* Snapshots now use rlang to print error and warning messages,
+  including the `Error:` and `Warning:` prefixes. This means the
+  `call` field of conditions is now displayed in snapshots if present.
+
+* By default, snapshots no longer show the class of errors, warnings,
+  and messages. Set the new argument `cnd_class = TRUE` to restore the
+  old behaviour.
+
+  We decided to change the default to prevent distracting snapshot
+  diffing as upstream packages add error classes. For instance, the
+  development version of R is adding classes to basic errors.
 
 
 # testthat 3.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,17 +4,35 @@
   like `!!`.
 
 * Fixed bug in expectations with long inputs that use `::` (#1472).
-* Snapshots now use rlang to print error and warning messages,
-  including the `Error:` and `Warning:` prefixes. This means the
-  `call` field of conditions is now displayed in snapshots if present.
 
-* By default, snapshots no longer show the class of errors, warnings,
-  and messages. Set the new argument `cnd_class = TRUE` to restore the
-  old behaviour.
+* Added preliminary support for rlang 1.0 errors. It is disabled by
+  default for the time being. To activate it, specify `rlang (>=
+  1.0.0)` in your `DESCRIPTION` file (or `>= 0.99.0.9001` if you're
+  using the dev version).
 
-  We decided to change the default to prevent distracting snapshot
+  Once activated, snapshots will now use rlang to print error and
+  warning messages, including the `Error:` and `Warning:`
+  prefixes. This means the `call` field of conditions is now displayed
+  in snapshots if present. Parent error messages are also displayed.
+  Following this change, all snapshots including error and warning
+  messages need to be revalidated.
+
+  We will enable the new rlang 1.0 output unconditionally in a future
+  release.
+
+* `expect_snapshot()` gains a new argument `cnd_class` to control
+  whether to show the class of errors, warnings, and messages.
+
+  The default is currently unchanged so that condition classes keep
+  being included in snapshots. However, we plan to change the default
+  to `FALSE` in an upcoming release to prevent distracting snapshot
   diffing as upstream packages add error classes. For instance, the
-  development version of R is adding classes to basic errors.
+  development version of R is currently adding classes to basic
+  errors, which causes spurious snapshot changes when testing against
+  R-devel on CI.
+
+  If you depend on rlang 1.0 (see above), the default is already set
+  to `FALSE`.
 
 
 # testthat 3.1.0

--- a/R/edition.R
+++ b/R/edition.R
@@ -82,3 +82,32 @@ edition_get <- function() {
   }
 }
 
+
+find_dep_version <- function(name, path, package = NULL) {
+  desc <- find_description(path, package)
+  if (is.null(desc)) {
+    return(NULL)
+  }
+
+  deps <- desc$get_deps()
+  i <- match(name, deps[["package"]])
+  if (is_na(i)) {
+    return(NULL)
+  }
+
+  dep <- deps[[i, "version"]]
+  dep <- strsplit(dep, " ")[[1]]
+  if (!is_character(dep, 2) && !is_string(dep[[1]], ">=")) {
+    return(NULL)
+  }
+
+  dep[[2]]
+}
+
+use_rlang_1_0 <- function() {
+  ver <- peek_option("testthat:::rlang_dep")
+  is_string(ver) && package_version(ver) >= "0.99.0.9001"
+}
+local_use_rlang_1_0 <- function(frame = caller_env()) {
+  local_options("testthat:::rlang_dep" = "1.0.0", .frame = frame)
+}

--- a/R/edition.R
+++ b/R/edition.R
@@ -108,6 +108,3 @@ use_rlang_1_0 <- function() {
   ver <- peek_option("testthat:::rlang_dep")
   is_string(ver) && package_version(ver) >= "0.99.0.9001"
 }
-local_use_rlang_1_0 <- function(frame = caller_env()) {
-  local_options("testthat:::rlang_dep" = "1.0.0", .frame = frame)
-}

--- a/R/local.R
+++ b/R/local.R
@@ -147,7 +147,16 @@ local_test_directory <- function(path, package = NULL, .env = parent.frame()) {
   # Set edition before changing working directory in case path is relative
   local_edition(find_edition(path, package), .env = .env)
 
-  withr::local_dir(path, .local_envir = .env)
+  rlang_dep <- find_dep_version("rlang", path, package)
+
+  withr::local_options(
+    "testthat:::rlang_dep" = rlang_dep,
+    .local_envir = .env
+  )
+  withr::local_dir(
+    path,
+    .local_envir = .env
+  )
   withr::local_envvar(
     R_TESTS = "",
     TESTTHAT = "true",

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -63,8 +63,16 @@
 #' @param transform Optionally, a function to scrub sensitive or stochastic
 #'   text from the output. Should take a character vector of lines as input
 #'   and return a modified character vector as output.
+#' @param cnd_class Whether to include the class of messages,
+#'   warnings, and errors in the snapshot. Only the most specific
+#'   class is included, i.e. the first element of `class(cnd)`.
 #' @export
-expect_snapshot <- function(x, cran = FALSE, error = FALSE, transform = NULL, variant = NULL) {
+expect_snapshot <- function(x,
+                            cran = FALSE,
+                            error = FALSE,
+                            transform = NULL,
+                            variant = NULL,
+                            cnd_class = FALSE) {
   edition_require(3, "expect_snapshot()")
   variant <- check_variant(variant)
   if (!is.null(transform)) {
@@ -75,9 +83,15 @@ expect_snapshot <- function(x, cran = FALSE, error = FALSE, transform = NULL, va
 
   # Execute code, capturing last error
   state <- new_environment(list(error = NULL))
-  out <- verify_exec(quo_get_expr(x), quo_get_env(x), {
-    function(x) snapshot_replay(x, state, transform)
-  })
+  replay <- function(x) {
+    snapshot_replay(
+      x,
+      state,
+      transform = transform,
+      cnd_class = cnd_class
+    )
+  }
+  out <- verify_exec(quo_get_expr(x), quo_get_env(x), replay)
 
   # Use expect_error() machinery to confirm that error is as expected
   msg <- compare_condition_3e("error", state$error, quo_label(x), error)
@@ -98,35 +112,39 @@ expect_snapshot <- function(x, cran = FALSE, error = FALSE, transform = NULL, va
   )
 }
 
-snapshot_replay <- function(x, state, transform = NULL) {
+snapshot_replay <- function(x, state, ..., transform = NULL) {
   UseMethod("snapshot_replay", x)
 }
 #' @export
-snapshot_replay.character <- function(x, state, transform = NULL) {
+snapshot_replay.character <- function(x, state, ..., transform = NULL) {
   c(snap_header(state, "Output"), snapshot_lines(x, transform))
 }
 #' @export
-snapshot_replay.source <- function(x, state, transform = NULL) {
+snapshot_replay.source <- function(x, state, ..., transform = NULL) {
   c(snap_header(state, "Code"), snapshot_lines(x$src))
 }
 #' @export
-snapshot_replay.condition <- function(x, state, transform = NULL) {
-  msg <- cnd_message(x)
-  if (inherits(x, "error")) {
-    state$error <- x
-    type <- "Error"
-  } else if (inherits(x, "warning")) {
-    type <- "Warning"
-  } else if (inherits(x, "message")) {
+snapshot_replay.condition <- function(x,
+                                      state,
+                                      ...,
+                                      transform = NULL,
+                                      cnd_class = FALSE) {
+  if (inherits(x, "message")) {
+    msg <- rlang::cnd_message(x)
     type <- "Message"
-    msg <- sub("\n$", "", msg)
   } else {
+    if (inherits(x, "error")) {
+      state$error <- x
+    }
+    msg <- rlang::cnd_message(x, prefix = TRUE)
     type <- "Condition"
   }
 
-  class <- paste0(type, " <", class(x)[[1]], ">")
+  if (cnd_class) {
+    type <- paste0(type, " <", class(x)[[1]], ">")
+  }
 
-  c(snap_header(state, class), snapshot_lines(msg, transform))
+  c(snap_header(state, type), snapshot_lines(msg, transform))
 }
 
 snapshot_lines <- function(x, transform = NULL) {

--- a/man/expect_snapshot.Rd
+++ b/man/expect_snapshot.Rd
@@ -12,7 +12,8 @@ expect_snapshot(
   cran = FALSE,
   error = FALSE,
   transform = NULL,
-  variant = NULL
+  variant = NULL,
+  cnd_class = FALSE
 )
 
 expect_snapshot_output(x, cran = FALSE, variant = NULL)
@@ -56,6 +57,10 @@ Variants are an advanced feature. When you use them, you'll need to
 carefully think about your testing strategy to ensure that all important
 variants are covered by automated tests, and ensure that you have a way
 to get snapshot changes out of your CI system and back into the repo.}
+
+\item{cnd_class}{Whether to include the class of messages,
+warnings, and errors in the snapshot. Only the most specific
+class is included, i.e. the first element of \code{class(cnd)}.}
 
 \item{class}{Class of expect error condition. The expectation will
 always fail (even on CRAN) if an error of this class isn't seen

--- a/tests/testthat/_snaps/rlang-1.0/snapshot.md
+++ b/tests/testthat/_snaps/rlang-1.0/snapshot.md
@@ -1,0 +1,40 @@
+# full condition message is printed with rlang
+
+    Code
+      foo <- error_cnd("foo", message = "Title parent.")
+      abort("Title.", parent = foo)
+    Condition
+      Error:
+        Title.
+      Caused by error:
+        Title parent.
+
+# can print with and without condition classes
+
+    Code
+      f()
+    Message <simpleMessage>
+      foo
+    Condition <simpleWarning>
+      Warning in `f()`: bar
+    Condition <simpleError>
+      Error in `f()`: baz
+
+---
+
+    Code
+      f()
+    Message
+      foo
+    Condition
+      Warning in `f()`: bar
+      Error in `f()`: baz
+
+# errors and warnings are folded
+
+    Code
+      f()
+    Condition
+      Warning in `f()`: foo
+      Error in `f()`: bar
+

--- a/tests/testthat/_snaps/rlang-pre-1.0/snapshot.md
+++ b/tests/testthat/_snaps/rlang-pre-1.0/snapshot.md
@@ -1,0 +1,39 @@
+# full condition message is printed with rlang
+
+    Code
+      foo <- error_cnd("foo", message = "Title parent.")
+      abort("Title.", parent = foo)
+    Error <rlang_error>
+      Title.
+
+# can print with and without condition classes
+
+    Code
+      f()
+    Message <simpleMessage>
+      foo
+    Warning <simpleWarning>
+      bar
+    Error <simpleError>
+      baz
+
+---
+
+    Code
+      f()
+    Message <simpleMessage>
+      foo
+    Warning <simpleWarning>
+      bar
+    Error <simpleError>
+      baz
+
+# errors and warnings are folded
+
+    Code
+      f()
+    Warning <simpleWarning>
+      foo
+    Error <simpleError>
+      bar
+

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -177,32 +177,3 @@
       x <- quote(!!foo)
       expect_equal(x, call("!", call("!", quote(foo))))
 
-# full condition message is printed with rlang
-
-    Code
-      abort("Title.", parent = foo)
-    Condition
-      Error:
-        Title.
-      Caused by error:
-        Title parent.
-
-# can print condition classes
-
-    Code
-      f()
-    Message <simpleMessage>
-      foo
-    Condition <simpleWarning>
-      Warning in `f()`: bar
-    Condition <simpleError>
-      Error in `f()`: baz
-
-# errors and warnings are folded
-
-    Code
-      f()
-    Condition
-      Warning in `f()`: foo
-      Error in `f()`: bar
-

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -177,3 +177,32 @@
       x <- quote(!!foo)
       expect_equal(x, call("!", call("!", quote(foo))))
 
+# full condition message is printed with rlang
+
+    Code
+      abort("Title.", parent = foo)
+    Condition
+      Error:
+        Title.
+      Caused by error:
+        Title parent.
+
+# can print condition classes
+
+    Code
+      f()
+    Message <simpleMessage>
+      foo
+    Condition <simpleWarning>
+      Warning in `f()`: bar
+    Condition <simpleError>
+      Error in `f()`: baz
+
+# errors and warnings are folded
+
+    Code
+      f()
+    Condition
+      Warning in `f()`: foo
+      Error in `f()`: bar
+

--- a/tests/testthat/helper-testthat.R
+++ b/tests/testthat/helper-testthat.R
@@ -1,0 +1,9 @@
+rlang_version <- function() {
+  if (use_rlang_1_0()) "rlang-1.0" else "rlang-pre-1.0"
+}
+
+local_use_rlang_1_0 <- function(frame = caller_env()) {
+  if (is_installed("rlang") && utils::packageVersion("rlang") >= "0.99.0.9001") {
+    local_options("testthat:::rlang_dep" = "1.0.0", .frame = frame)
+  }
+}

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -112,7 +112,18 @@ test_that("`expect_snapshot()` does not inject", {
   })
 })
 
+test_that("full condition message is printed with rlang", {
+  skip_if_not_installed("rlang", "0.99.0.9001")
+  local_use_rlang_1_0()
+
+  foo <- error_cnd("foo", message = "Title parent.")
+  expect_snapshot(error = TRUE, abort("Title.", parent = foo))
+})
+
 test_that("can print condition classes", {
+  skip_if_not_installed("rlang", "0.99.0.9001")
+  local_use_rlang_1_0()
+
   f <- function() {
     message("foo")
     warning("bar")
@@ -122,6 +133,9 @@ test_that("can print condition classes", {
 })
 
 test_that("errors and warnings are folded", {
+  skip_if_not_installed("rlang", "0.99.0.9001")
+  local_use_rlang_1_0()
+
   f <- function() {
     warning("foo")
     stop("bar")

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -113,15 +113,19 @@ test_that("`expect_snapshot()` does not inject", {
 })
 
 test_that("full condition message is printed with rlang", {
-  skip_if_not_installed("rlang", "0.99.0.9001")
   local_use_rlang_1_0()
 
-  foo <- error_cnd("foo", message = "Title parent.")
-  expect_snapshot(error = TRUE, abort("Title.", parent = foo))
+  expect_snapshot(
+    error = TRUE,
+    variant = rlang_version(),
+    {
+      foo <- error_cnd("foo", message = "Title parent.")
+      abort("Title.", parent = foo)
+    }
+  )
 })
 
-test_that("can print condition classes", {
-  skip_if_not_installed("rlang", "0.99.0.9001")
+test_that("can print with and without condition classes", {
   local_use_rlang_1_0()
 
   f <- function() {
@@ -129,16 +133,30 @@ test_that("can print condition classes", {
     warning("bar")
     stop("baz")
   }
-  expect_snapshot(error = TRUE, cnd_class = TRUE, f())
+  expect_snapshot(
+    error = TRUE,
+    cnd_class = TRUE,
+    variant = rlang_version(),
+    f()
+  )
+  expect_snapshot(
+    error = TRUE,
+    cnd_class = FALSE,
+    variant = rlang_version(),
+    f()
+  )
 })
 
 test_that("errors and warnings are folded", {
-  skip_if_not_installed("rlang", "0.99.0.9001")
   local_use_rlang_1_0()
 
   f <- function() {
     warning("foo")
     stop("bar")
   }
-  expect_snapshot(error = TRUE, f())
+  expect_snapshot(
+    error = TRUE,
+    variant = rlang_version(),
+    f()
+  )
 })

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -111,3 +111,20 @@ test_that("`expect_snapshot()` does not inject", {
     expect_equal(x, call("!", call("!", quote(foo))))
   })
 })
+
+test_that("can print condition classes", {
+  f <- function() {
+    message("foo")
+    warning("bar")
+    stop("baz")
+  }
+  expect_snapshot(error = TRUE, cnd_class = TRUE, f())
+})
+
+test_that("errors and warnings are folded", {
+  f <- function() {
+    warning("foo")
+    stop("bar")
+  }
+  expect_snapshot(error = TRUE, f())
+})


### PR DESCRIPTION
Depends on r-lib/rlang#1313.

* Update snapshots
* Don't show error class by default. New argument `cnd_class` allows opting into the old behaviour.
* Use rlang to print full prefixed error and warnings messages. Conditions of class `message` are still printed without prefix.