### PR TITLE
Don't process rlang injection operators in `expect_snapshot()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # testthat (development version)
 
+* `expect_snapshot()` no longer processes rlang injection operators
+  like `!!`.
+
+
 # testthat 3.1.0
 
 ## Snapshot tests

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -71,7 +71,7 @@ expect_snapshot <- function(x, cran = FALSE, error = FALSE, transform = NULL, va
     transform <- as_function(transform)
   }
 
-  x <- enquo(x)
+  x <- enquo0(x)
 
   # Execute code, capturing last error
   state <- new_environment(list(error = NULL))

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -171,3 +171,9 @@
 
     0.9
 
+# `expect_snapshot()` does not inject
+
+    Code
+      x <- quote(!!foo)
+      expect_equal(x, call("!", call("!", quote(foo))))
+

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -104,3 +104,10 @@ test_that("reparse handles common cases", {
   f <- function(x) x + 1
   expect_equal(roundtrip(f), f, ignore_function_env = TRUE)
 })
+
+test_that("`expect_snapshot()` does not inject", {
+  expect_snapshot({
+    x <- quote(!!foo)
+    expect_equal(x, call("!", call("!", quote(foo))))
+  })
+})


### PR DESCRIPTION
Injection causes various subtle bugs. In particular it causes parse errors since the input is reparsed from `expr_deparse()` which uses special `<type>` syntax for injected objects.