### PR TITLE
Match conditions across ancestry

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,4 +60,4 @@ Config/testthat/edition: 3
 Config/testthat/start-first: watcher, parallel*
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE, r6 = FALSE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.1.2.9000

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 
 * Fixed bug in expectations with long inputs that use `::` (#1472).
 
+* Condition expectations like `expect_error()` now match across the
+  ancestry of chained errors (#1493).
+
 
 # testthat 3.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,8 @@
 * Fixed bug in expectations with long inputs that use `::` (#1472).
 
 * Condition expectations like `expect_error()` now match across the
-  ancestry of chained errors (#1493).
+  ancestry of chained errors (#1493). You can disable this by setting
+  the new `inherit` argument to `FALSE`.
 
 
 # testthat 3.1.0

--- a/man/expect_error.Rd
+++ b/man/expect_error.Rd
@@ -12,6 +12,7 @@ expect_error(
   regexp = NULL,
   class = NULL,
   ...,
+  inherit = TRUE,
   info = NULL,
   label = NULL
 )
@@ -21,6 +22,7 @@ expect_warning(
   regexp = NULL,
   class = NULL,
   ...,
+  inherit = TRUE,
   all = FALSE,
   info = NULL,
   label = NULL
@@ -31,6 +33,7 @@ expect_message(
   regexp = NULL,
   class = NULL,
   ...,
+  inherit = TRUE,
   all = FALSE,
   info = NULL,
   label = NULL
@@ -41,6 +44,7 @@ expect_condition(
   regexp = NULL,
   class = NULL,
   ...,
+  inherit = TRUE,
   info = NULL,
   label = NULL
 )
@@ -70,6 +74,9 @@ a class name. This is useful for "classed" conditions.}
     \item{\code{fixed}}{logical.  If \code{TRUE}, \code{pattern} is a string to be
     matched as is.  Overrides all conflicting arguments.}
   }}
+
+\item{inherit}{Whether to match \code{regexp} and \code{class} across the
+ancestry of chained errors.}
 
 \item{info}{Extra information to be included in the message. This argument
 is soft-deprecated and should not be used in new code. Instead see

--- a/tests/testthat/test-expect-condition.R
+++ b/tests/testthat/test-expect-condition.R
@@ -174,6 +174,10 @@ test_that("can match parent conditions (#1493)", {
 
   # Pattern and class must match the same condition
   expect_error(expect_error(f(), "Tilt.", class = "foo"))
+
+  # Can disable parent matching
+  expect_error(expect_error(f(), class = "foo", inherit = FALSE))
+  expect_error(expect_error(f(), "Parent message.", inherit = FALSE))
 })
 
 
@@ -216,4 +220,8 @@ test_that("can match parent conditions (edition 2, #1493)", {
 
   expect_error(f(), class = "foo")
   expect_error(f(), "^Parent message.$")
+
+  # Can disable parent matching
+  expect_error(expect_error(f(), class = "foo", inherit = FALSE))
+  expect_error(expect_error(f(), "Parent message.", inherit = FALSE))
 })

--- a/tests/testthat/test-expect-condition.R
+++ b/tests/testthat/test-expect-condition.R
@@ -165,6 +165,17 @@ test_that("cli width wrapping doesn't affect text matching", {
   )
 })
 
+test_that("can match parent conditions (#1493)", {
+  parent <- error_cnd("foo", message = "Parent message.")
+  f <- function() abort("Tilt.", parent = parent)
+
+  expect_error(f(), class = "foo")
+  expect_error(f(), "^Parent message.$")
+
+  # Pattern and class must match the same condition
+  expect_error(expect_error(f(), "Tilt.", class = "foo"))
+})
+
 
 # second edition ----------------------------------------------------------
 
@@ -197,3 +208,12 @@ test_that("other conditions are swallowed", {
   expect_warning(expect_warning(f("warning", "warning")), NA)
 })
 
+test_that("can match parent conditions (edition 2, #1493)", {
+  local_edition(2)
+
+  parent <- error_cnd("foo", message = "Parent message.")
+  f <- function() abort("Tilt.", parent = parent)
+
+  expect_error(f(), class = "foo")
+  expect_error(f(), "^Parent message.$")
+})


### PR DESCRIPTION
Closes #1493

With r-lib/rlang#1320, the parent messages are included in `conditionMessage()`, which partially solves regex matching (and more importantly provides compatibility with rmarkdown). With this PR, condition matching across the ancestry is implemented in such a way that regexps involving `^` and `$` keep working as expected. Also, `class` is properly matched.