### PR TITLE
Add snapshot_review() in the hint of snapshots

### DIFF
--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -280,7 +280,7 @@ expect_snapshot_helper <- function(lab, val,
     tolerance = tolerance,
     variant = variant
   )
-  hint <- paste0("Run `snapshot_accept('", snapshotter$file, "')` if this is a deliberate change")
+  hint <- paste0("Run `snapshot_review('", snapshotter$file, "')` to review the change or `snapshot_accept('", snapshotter$file, "')` if is deliberate.")
 
   expect(
     length(comp) == 0,

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -280,7 +280,7 @@ expect_snapshot_helper <- function(lab, val,
     tolerance = tolerance,
     variant = variant
   )
-  hint <- paste0("Run `snapshot_review('", snapshotter$file, "')` to review the change or `snapshot_accept('", snapshotter$file, "')` if is deliberate.")
+  hint <- paste0("Run `snapshot_review('", snapshotter$file, "')` to review the change or `snapshot_accept('", snapshotter$file, "')` if it is deliberate.")
 
   expect(
     length(comp) == 0,


### PR DESCRIPTION
Hi, 

Copypasting the `Run snapshot_accept("my_file") if this is a deliberate change` hint to the console is a game-changer when using snapshots! 

However, one does not often blindly accept changes, so `snapshot_review()` seems more adapted, at least to my use.

Not sure about the grammar though (I never know when "change" should be plural in English).
