### PR TITLE
Add `in_snapshotter()` and return conditions visibly when snapshotting

### DIFF
--- a/R/expect-condition.R
+++ b/R/expect-condition.R
@@ -264,8 +264,17 @@ expect_condition_matching <- function(base_class,
   expect(is.null(msg), msg, info = info, trace = act$cap[["trace"]])
 
   # If a condition was expected, return it. Otherwise return the value
-  # of the expression.
-  invisible(if (expected) act$cap else act$val)
+  # of the expression. If we are returning the condition and we are in
+  # a snapshotter, return it visibly so the snapshotter can capture it
+  if (expected) {
+    if (in_snapshotter()) {
+      act$cap
+    } else {
+      invisible(act$cap)
+    }
+  } else {
+    invisible(act$val)
+  }
 }
 
 # -------------------------------------------------------------------------

--- a/R/snapshot-file.R
+++ b/R/snapshot-file.R
@@ -87,6 +87,7 @@ expect_snapshot_file <- function(path,
                                  compare =  compare_file_binary,
                                  variant = NULL) {
   edition_require(3, "expect_snapshot_file()")
+  withr::local_options("testthat.in_snapshot" = TRUE)
   if (!cran && !interactive() && on_cran()) {
     skip("On CRAN")
   }

--- a/R/snapshot-reporter.R
+++ b/R/snapshot-reporter.R
@@ -155,6 +155,16 @@ get_snapshotter <- function() {
   x
 }
 
+in_snapshotter <- function() {
+  x <- getOption("testthat.snapshotter")
+
+  if (is.null(x)) {
+    return(FALSE)
+  }
+
+  x$is_active()
+}
+
 #' Instantiate local snapshotting context
 #'
 #' Needed if you want to run snapshot tests outside of the usual testthat

--- a/R/snapshot-reporter.R
+++ b/R/snapshot-reporter.R
@@ -156,13 +156,7 @@ get_snapshotter <- function() {
 }
 
 in_snapshotter <- function() {
-  x <- getOption("testthat.snapshotter")
-
-  if (is.null(x)) {
-    return(FALSE)
-  }
-
-  x$is_active()
+  isTRUE(getOption("testthat.in_snapshot"))
 }
 
 #' Instantiate local snapshotting context

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -74,6 +74,8 @@ expect_snapshot <- function(x,
                             variant = NULL,
                             cnd_class = FALSE) {
   edition_require(3, "expect_snapshot()")
+  withr::local_options("testthat.in_snapshot" = TRUE)
+
   variant <- check_variant(variant)
   if (!is.null(transform)) {
     transform <- as_function(transform)
@@ -196,6 +198,7 @@ snap_header <- function(state, header) {
 #' @rdname expect_snapshot
 expect_snapshot_output <- function(x, cran = FALSE, variant = NULL) {
   edition_require(3, "expect_snapshot_output()")
+  withr::local_options("testthat.in_snapshot" = TRUE)
   variant <- check_variant(variant)
 
   lab <- quo_label(enquo(x))
@@ -216,6 +219,7 @@ expect_snapshot_output <- function(x, cran = FALSE, variant = NULL) {
 #' @rdname expect_snapshot
 expect_snapshot_error <- function(x, class = "error", cran = FALSE, variant = NULL) {
   edition_require(3, "expect_snapshot_error()")
+  withr::local_options("testthat.in_snapshot" = TRUE)
   variant <- check_variant(variant)
 
   lab <- quo_label(enquo(x))
@@ -253,6 +257,7 @@ expect_snapshot_value <- function(x,
                                   ...,
                                   variant = NULL) {
   edition_require(3, "expect_snapshot_value()")
+  withr::local_options("testthat.in_snapshot" = TRUE)
   variant <- check_variant(variant)
   lab <- quo_label(enquo(x))
 

--- a/tests/testthat/_snaps/expect-condition.md
+++ b/tests/testthat/_snaps/expect-condition.md
@@ -12,3 +12,11 @@
     Message: dispatched!
     Class:   foobar/rlang_error/error/condition
 
+# expected conditions are returned visibly while in a snapshotter (#1471)
+
+    Code
+      expect_error(abort("Oh no!"))
+    Output
+      <error/rlang_error>
+      Oh no!
+

--- a/tests/testthat/test-expect-condition.R
+++ b/tests/testthat/test-expect-condition.R
@@ -69,7 +69,6 @@ test_that("can capture Throwable conditions from rJava", {
 })
 
 test_that("expected conditions are typically returned invisibly", {
-  # TODO: This currently fails
   expect_invisible(expect_error(abort("Oh no!")))
 })
 

--- a/tests/testthat/test-expect-condition.R
+++ b/tests/testthat/test-expect-condition.R
@@ -68,6 +68,15 @@ test_that("can capture Throwable conditions from rJava", {
   expect_error(throw("foo"), "foo", class = "Throwable")
 })
 
+test_that("expected conditions are typically returned invisibly", {
+  # TODO: This currently fails
+  expect_invisible(expect_error(abort("Oh no!")))
+})
+
+test_that("expected conditions are returned visibly while in a snapshotter (#1471)", {
+  expect_snapshot(expect_error(abort("Oh no!")))
+})
+
 # expect_warning() ----------------------------------------------------------
 
 test_that("warnings are converted to errors when options('warn') >= 2", {


### PR DESCRIPTION
This is currently broken, because `in_snapshotter()` seems to _always_ return `TRUE` when testing a file or directory, and _always_ return `FALSE` when running a test interactively. Both of these are incorrect.

We need something that is more fine grained. I think `expect_snapshot()` itself might need to set something that announces that you are "in a snapshot expectation". That would mean that both interactive and non-interactive testing could return visible conditions where appropriate.