### PR TITLE
Fix snapshots of conditions with empty lines

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: testthat
 Title: Unit Testing for R
-Version: 3.1.1.9000
+Version: 3.1.1.9001
 Authors@R: 
     c(person(given = "Hadley",
              family = "Wickham",

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -154,7 +154,7 @@ snapshot_replay.condition <- function(x,
     type <- paste0(type, " <", class(x)[[1]], ">")
   }
 
-  c(snap_header(state, type), snapshot_lines(msg, transform))
+  c(snap_header(state, type), snapshot_lines(msg, transform, keep_empty = TRUE))
 }
 
 snapshot_replay_condition_legacy <- function(x, state, transform = NULL) {
@@ -173,15 +173,15 @@ snapshot_replay_condition_legacy <- function(x, state, transform = NULL) {
 
   class <- paste0(type, " <", class(x)[[1]], ">")
 
-  c(snap_header(state, class), snapshot_lines(msg, transform))
+  c(snap_header(state, class), snapshot_lines(msg, transform, keep_empty = TRUE))
 }
 
-snapshot_lines <- function(x, transform = NULL) {
+snapshot_lines <- function(x, transform = NULL, keep_empty = FALSE) {
   x <- split_lines(x)
   if (!is.null(transform)) {
     x <- transform(x)
   }
-  x <- indent(x)
+  x <- indent(x, keep_empty = keep_empty)
   x
 }
 
@@ -360,7 +360,13 @@ local_snapshot_dir <- function(snap_names, .env = parent.frame()) {
 }
 
 # if transform() wiped out the full message, don't indent, #1487
-indent <- function(x) if (length(x)) paste0("  ", x) else x
+indent <- function(x, keep_empty = FALSE) {
+  if (keep_empty || length(x)) {
+    paste0("  ", x)
+  } else {
+    x
+  }
+}
 
 check_variant <- function(x) {
   if (is.null(x)) {


### PR DESCRIPTION
It seems to me that the simplest is to treat snapshots of conditions differently. So for these we dot remove the empty lines now. 

To have a workaround that works with both testthat 3.1.1 (removing the empty lines), record your test with testthat 3.1.0 or with the fix included in this PR (will be version 3.1.1.9001) and skip them on the problematic testthat versions. E.g. something like this in a `helper.R` file should work:

```r
expect_snapshot <- function(...) {
  if (packageVersion("testthat") >= "3.1.1" &&
      packageVersion("testthat") <= "3.1.1.9000") {
    skip("testthat bug with snapshots")
  }
  testthat::expect_snapshot(...)
}
```

Closes #1509.