### PR TITLE
Remove snap directory if it is empty

### DIFF
--- a/R/snapshot-cleanup.R
+++ b/R/snapshot-cleanup.R
@@ -13,7 +13,7 @@ snapshot_cleanup <- function(path, test_files_seen = character(), snap_files_see
   unlink(empty, recursive = TRUE)
 
   # Delete snapshot folder
-  if (length(dir(path)) == 0) { 
+  if (is_dir_empty(path)) { 
     unlink(path, recursive = TRUE) 
   }
 

--- a/R/snapshot-cleanup.R
+++ b/R/snapshot-cleanup.R
@@ -12,6 +12,11 @@ snapshot_cleanup <- function(path, test_files_seen = character(), snap_files_see
   empty <- dirs[map_lgl(dirs, is_dir_empty)]
   unlink(empty, recursive = TRUE)
 
+  # Delete snapshot folder
+  if (length(dir(path)) == 0) { 
+    unlink(path, recursive = TRUE) 
+  }
+
   rstudio_tickle()
 
   invisible(outdated)


### PR DESCRIPTION
Followup to https://github.com/r-lib/testthat/pull/1529, restoring some prior logic: https://github.com/r-lib/testthat/pull/1529/files#diff-f12fc9a44aa59e4ec0c87b1d980f4221e2f8c10e4abce49822e7425104073f84L10-L12

If all snap sub folders have removed in the prior step, then the `_snaps` dir is empty. This empty dir should also be removed.