### PR TITLE
Fail when a new variant is found on CI (not just warn)

### DIFF
--- a/R/expect-condition.R
+++ b/R/expect-condition.R
@@ -153,7 +153,8 @@ expect_warning <- function(object,
       ...,
       inherit = inherit,
       info = info,
-      label = label
+      label = label,
+      trace_env = caller_env()
     )
   } else {
     act <- quasi_capture(enquo(object), label, capture_warnings)
@@ -185,7 +186,8 @@ expect_message <- function(object,
       ...,
       inherit = inherit,
       info = info,
-      label = label
+      label = label,
+      trace_env = caller_env()
     )
   } else {
     act <- quasi_capture(enquo(object), label, capture_messages)
@@ -213,7 +215,8 @@ expect_condition <- function(object,
       ...,
       inherit = inherit,
       info = info,
-      label = label
+      label = label,
+      trace_env = caller_env()
     )
   } else {
     act <- quasi_capture(enquo(object), label, capture_condition, entrace = TRUE)
@@ -239,7 +242,8 @@ expect_condition_matching <- function(base_class,
                                       ...,
                                       inherit = TRUE,
                                       info = NULL,
-                                      label = NULL) {
+                                      label = NULL,
+                                      trace_env = caller_env()) {
   ellipsis::check_dots_used(action = warn)
 
   matcher <- cnd_matcher(
@@ -261,7 +265,7 @@ expect_condition_matching <- function(base_class,
 
   # Access error fields with `[[` rather than `$` because the
   # `$.Throwable` from the rJava package throws with unknown fields
-  expect(is.null(msg), msg, info = info, trace = act$cap[["trace"]])
+  expect(is.null(msg), msg, info = info, trace = act$cap[["trace"]], trace_env = trace_env)
 
   # If a condition was expected, return it. Otherwise return the value
   # of the expression.

--- a/R/snapshot-file.R
+++ b/R/snapshot-file.R
@@ -126,7 +126,11 @@ expect_snapshot_file <- function(path,
   }
 
   lab <- quo_label(enquo(path))
-  equal <- snapshotter$take_file_snapshot(name, path, compare, variant = variant)
+  equal <- snapshotter$take_file_snapshot(name, path,
+    file_equal = compare,
+    variant = variant,
+    trace_env = caller_env()
+  )
   hint <- snapshot_hint(snapshotter$file, name)
 
   expect(
@@ -162,7 +166,7 @@ snapshot_hint <- function(test, name, ci = on_ci(), check = in_rcmd_check()) {
   )
 }
 
-snapshot_file_equal <- function(snap_test_dir, snap_name, path, file_equal = compare_file_binary) {
+snapshot_file_equal <- function(snap_test_dir, snap_name, path, file_equal = compare_file_binary, fail_on_new = FALSE, trace_env = NULL) {
   if (!file.exists(path)) {
     abort(paste0("`", path, "` not found"))
   }
@@ -182,7 +186,14 @@ snapshot_file_equal <- function(snap_test_dir, snap_name, path, file_equal = com
   } else {
     dir.create(snap_test_dir, showWarnings = FALSE, recursive = TRUE)
     file.copy(path, cur_path)
-    testthat_warn(paste0("Adding new file snapshot: '", cur_path, "'"))
+
+    message <- paste0("Adding new file snapshot: '", cur_path, "'")
+    if (fail_on_new) {
+      fail(message, trace_env = trace_env)
+    } else {
+      testthat_warn(message)
+    }
+
     TRUE
   }
 }

--- a/R/snapshot-file.R
+++ b/R/snapshot-file.R
@@ -187,7 +187,7 @@ snapshot_file_equal <- function(snap_test_dir, snap_name, path, file_equal = com
     dir.create(snap_test_dir, showWarnings = FALSE, recursive = TRUE)
     file.copy(path, cur_path)
 
-    message <- paste0("Adding new file snapshot: '", cur_path, "'")
+    message <- paste0("Adding new file snapshot: 'tests/testhat/_snaps/", snap_name, "'")
     if (fail_on_new) {
       fail(message, trace_env = trace_env)
     } else {

--- a/R/snapshot-reporter.R
+++ b/R/snapshot-reporter.R
@@ -138,7 +138,7 @@ SnapshotReporter <- R6::R6Class("SnapshotReporter",
     end_reporter = function() {
       # clean up if we've seen all files
       tests <- context_name(find_test_scripts(".", full.names = FALSE))
-      if (all(tests %in% self$test_file_seen)) {
+      if (!on_ci() && all(tests %in% self$test_file_seen)) {
         snapshot_cleanup(self$snap_dir,
           test_files_seen = self$test_file_seen,
           snap_files_seen = self$snap_file_seen

--- a/R/snapshot-reporter.R
+++ b/R/snapshot-reporter.R
@@ -42,7 +42,8 @@ SnapshotReporter <- R6::R6Class("SnapshotReporter",
                              load = identity,
                              ...,
                              tolerance = testthat_tolerance(),
-                             variant = NULL) {
+                             variant = NULL,
+                             trace_env = NULL) {
       i <- self$new_snaps$append(self$test, variant, save(value))
 
       old_raw <- self$old_snaps$get(self$test, variant, i)
@@ -71,20 +72,17 @@ SnapshotReporter <- R6::R6Class("SnapshotReporter",
 
         self$cur_snaps$append(self$test, variant, value_enc)
 
-        if (!on_ci()) {
-          testthat_warn(paste0(
-            "Adding new snapshot",
-            if (variant != "_default") paste0(" to variant '", variant, "'"),
-            ":\n",
-            value_enc
-          ))
+        message <- paste0(
+          "Adding new snapshot",
+          if (variant != "_default") paste0(" for variant '", variant, "'"),
+          if (on_ci()) " in CI",
+          ":\n",
+          value_enc
+        )
+        if (on_ci()) {
+          fail(message, trace_env = trace_env)
         } else {
-          fail(paste0(
-            "Creating new snapshot",
-            if (variant != "_default") paste0(" for variant '", variant, "'"),
-            " in CI:\n",
-            value_enc
-          ))
+          testthat_warn(message)
         }
         character()
       }

--- a/R/snapshot-reporter.R
+++ b/R/snapshot-reporter.R
@@ -76,6 +76,9 @@ SnapshotReporter <- R6::R6Class("SnapshotReporter",
           ":\n",
           value_enc
         ))
+        if (on_ci()) {
+          stop("A CI error may be required to retrieve the new snapshot variant as an artifact; failing.")
+        }
         character()
       }
     },

--- a/R/snapshot-reporter.R
+++ b/R/snapshot-reporter.R
@@ -90,7 +90,7 @@ SnapshotReporter <- R6::R6Class("SnapshotReporter",
       }
     },
 
-    take_file_snapshot = function(name, path, file_equal, variant = NULL) {
+    take_file_snapshot = function(name, path, file_equal, variant = NULL, trace_env = NULL) {
       self$announce_file_snapshot(name)
 
       if (is.null(variant)) {
@@ -98,8 +98,16 @@ SnapshotReporter <- R6::R6Class("SnapshotReporter",
       } else {
         snap_dir <- file.path(self$snap_dir, variant, self$file)
       }
-      snapshot_file_equal(snap_dir, name, path, file_equal)
+      snapshot_file_equal(
+        snap_test_dir = snap_dir,
+        snap_name = name,
+        path = path,
+        file_equal = file_equal,
+        fail_on_new = self$fail_on_new,
+        trace_env = trace_env
+      )
     },
+
     # Also called from announce_snapshot_file()
     announce_file_snapshot = function(name) {
       self$snap_file_seen <- c(self$snap_file_seen, file.path(self$file, name))

--- a/R/snapshot-reporter.R
+++ b/R/snapshot-reporter.R
@@ -14,7 +14,7 @@ SnapshotReporter <- R6::R6Class("SnapshotReporter",
     cur_snaps = NULL,
     new_snaps = NULL,
 
-    initialize = function(snap_dir = "_snaps", fail_on_new = on_ci()) {
+    initialize = function(snap_dir = "_snaps", fail_on_new = FALSE) {
       self$snap_dir <- normalizePath(snap_dir, mustWork = FALSE)
       self$fail_on_new <- fail_on_new
     },
@@ -189,9 +189,9 @@ get_snapshotter <- function() {
 #'
 #' @export
 #' @keywords internal
-local_snapshotter <- function(snap_dir = NULL, cleanup = FALSE, .env = parent.frame()) {
+local_snapshotter <- function(snap_dir = NULL, cleanup = FALSE, fail_on_new = FALSE, .env = parent.frame()) {
   snap_dir <- snap_dir %||% withr::local_tempdir(.local_envir = .env)
-  reporter <- SnapshotReporter$new(snap_dir = snap_dir, fail_on_new = FALSE)
+  reporter <- SnapshotReporter$new(snap_dir = snap_dir, fail_on_new = fail_on_new)
   if (!identical(cleanup, FALSE)) {
     warn("`cleanup` is deprecated")
   }

--- a/R/snapshot-reporter.R
+++ b/R/snapshot-reporter.R
@@ -70,14 +70,21 @@ SnapshotReporter <- R6::R6Class("SnapshotReporter",
         check_roundtrip(value, load(value_enc), ..., tolerance = tolerance)
 
         self$cur_snaps$append(self$test, variant, value_enc)
-        testthat_warn(paste0(
-          "Adding new snapshot",
-          if (variant != "_default") paste0(" to variant '", variant, "'"),
-          ":\n",
-          value_enc
-        ))
-        if (on_ci()) {
-          stop("A CI error may be required to retrieve the new snapshot variant as an artifact; failing.")
+
+        if (!on_ci()) {
+          testthat_warn(paste0(
+            "Adding new snapshot",
+            if (variant != "_default") paste0(" to variant '", variant, "'"),
+            ":\n",
+            value_enc
+          ))
+        } else {
+          fail(paste0(
+            "Creating new snapshot",
+            if (variant != "_default") paste0(" for variant '", variant, "'"),
+            " in CI:\n",
+            value_enc
+          ))
         }
         character()
       }

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -111,7 +111,8 @@ expect_snapshot <- function(x,
     cran = cran,
     save = function(x) paste0(x, collapse = "\n"),
     load = function(x) split_by_line(x)[[1]],
-    variant = variant
+    variant = variant,
+    trace_env = caller_env()
   )
 }
 
@@ -208,7 +209,8 @@ expect_snapshot_output <- function(x, cran = FALSE, variant = NULL) {
     cran = cran,
     save = function(x) paste0(x, collapse = "\n"),
     load = function(x) split_by_line(x)[[1]],
-    variant = variant
+    variant = variant,
+    trace_env = caller_env()
   )
 }
 
@@ -256,7 +258,8 @@ expect_snapshot_condition <- function(base_class, x, class, cran = FALSE, varian
     lab,
     conditionMessage(val),
     cran = cran,
-    variant = variant
+    variant = variant,
+    trace_env = caller_env()
   )
 }
 
@@ -307,7 +310,8 @@ expect_snapshot_value <- function(x,
     cran = cran,
     ...,
     tolerance = tolerance,
-    variant = variant
+    variant = variant,
+    trace_env = caller_env()
   )
 }
 
@@ -338,7 +342,8 @@ expect_snapshot_helper <- function(lab, val,
                                    load = identity,
                                    ...,
                                    tolerance = testthat_tolerance(),
-                                   variant = NULL
+                                   variant = NULL,
+                                   trace_env = caller_env()
                                    ) {
   if (!cran && !interactive() && on_cran()) {
     skip("On CRAN")
@@ -356,7 +361,7 @@ expect_snapshot_helper <- function(lab, val,
     ...,
     tolerance = tolerance,
     variant = variant,
-    trace_env = caller_env()
+    trace_env = trace_env
   )
 
   hint <- snapshot_accept_hint(variant, snapshotter$file)
@@ -369,7 +374,7 @@ expect_snapshot_helper <- function(lab, val,
       paste0(comp, collapse = "\n\n"),
       hint
     ),
-    trace_env = caller_env()
+    trace_env = trace_env
   )
 }
 

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -355,7 +355,8 @@ expect_snapshot_helper <- function(lab, val,
     load = load,
     ...,
     tolerance = tolerance,
-    variant = variant
+    variant = variant,
+    trace_env = caller_env()
   )
 
   hint <- snapshot_accept_hint(variant, snapshotter$file)

--- a/R/test-files.R
+++ b/R/test-files.R
@@ -247,7 +247,7 @@ test_files_reporter <- function(reporter, .env = parent.frame()) {
   reporters <- list(
     find_reporter(reporter),
     lister, # track data
-    local_snapshotter("_snaps", .env = .env) # for snapshots
+    local_snapshotter("_snaps", fail_on_new = on_ci(), .env = .env) # for snapshots
   )
   list(
     multi = MultiReporter$new(reporters = compact(reporters)),

--- a/R/test-files.R
+++ b/R/test-files.R
@@ -247,7 +247,7 @@ test_files_reporter <- function(reporter, .env = parent.frame()) {
   reporters <- list(
     find_reporter(reporter),
     lister, # track data
-    local_snapshotter("_snaps", fail_on_new = on_ci(), .env = .env) # for snapshots
+    local_snapshotter("_snaps", fail_on_new = FALSE, .env = .env) # for snapshots
   )
   list(
     multi = MultiReporter$new(reporters = compact(reporters)),

--- a/man/local_snapshotter.Rd
+++ b/man/local_snapshotter.Rd
@@ -4,7 +4,12 @@
 \alias{local_snapshotter}
 \title{Instantiate local snapshotting context}
 \usage{
-local_snapshotter(snap_dir = NULL, cleanup = FALSE, .env = parent.frame())
+local_snapshotter(
+  snap_dir = NULL,
+  cleanup = FALSE,
+  fail_on_new = FALSE,
+  .env = parent.frame()
+)
 }
 \description{
 Needed if you want to run snapshot tests outside of the usual testthat


### PR DESCRIPTION
As mentioned in #1538, a failure appears to be necessary to generate artifacts.

I am not sure if this is a GHA-only thing, in which case we could try fine-tuning this more. Also happy to change the approach -- e.g. if we want to just `stop()` in lieu of `testthat_warn()`, rather than in addition to it as is done here.

Filing this approach now for feedback / to start discussion.