### PR TITLE
Introduce tolerance to inequality comparisons (non-strict)

### DIFF
--- a/R/expect-comparison.R
+++ b/R/expect-comparison.R
@@ -2,6 +2,8 @@
 #'
 #' @inheritParams expect_equal
 #' @param expected Single numeric value to compare.
+#' @param tolerance Non-negative scalar. For non-strict inequality comparisons,
+#'  the supplied value is propagated to all.equal(). Defaults to 0.
 #' @family expectations
 #' @examples
 #' a <- 9

--- a/R/expect-comparison.R
+++ b/R/expect-comparison.R
@@ -66,11 +66,13 @@ expect_lt <- function(object, expected, label = NULL, expected.label = NULL) {
 
 #' @export
 #' @rdname comparison-expectations
-expect_lte <- function(object, expected, label = NULL, expected.label = NULL) {
+expect_lte <- function(object, expected,
+                       label = NULL, expected.label = NULL,
+                       tolerance = 0) {
   act <- quasi_label(enquo(object), label, arg = "object")
   exp <- quasi_label(enquo(expected), expected.label, arg = "expected")
 
-  expect_compare("<=", act, exp)
+  expect_compare("<=", act, exp, tolerance)
 }
 
 #' @export
@@ -84,11 +86,13 @@ expect_gt <- function(object, expected, label = NULL, expected.label = NULL) {
 
 #' @export
 #' @rdname comparison-expectations
-expect_gte <- function(object, expected, label = NULL, expected.label = NULL) {
+expect_gte <- function(object, expected,
+                       label = NULL, expected.label = NULL,
+                       tolerance = 0) {
   act <- quasi_label(enquo(object), label, arg = "object")
   exp <- quasi_label(enquo(expected), expected.label, arg = "expected")
 
-  expect_compare(">=", act, exp)
+  expect_compare(">=", act, exp, tolerance)
 }
 
 

--- a/man/comparison-expectations.Rd
+++ b/man/comparison-expectations.Rd
@@ -10,11 +10,23 @@
 \usage{
 expect_lt(object, expected, label = NULL, expected.label = NULL)
 
-expect_lte(object, expected, label = NULL, expected.label = NULL)
+expect_lte(
+  object,
+  expected,
+  label = NULL,
+  expected.label = NULL,
+  tolerance = 0
+)
 
 expect_gt(object, expected, label = NULL, expected.label = NULL)
 
-expect_gte(object, expected, label = NULL, expected.label = NULL)
+expect_gte(
+  object,
+  expected,
+  label = NULL,
+  expected.label = NULL,
+  tolerance = 0
+)
 }
 \arguments{
 \item{object}{Computation and value to compare it to.
@@ -30,6 +42,9 @@ use only.}
 
 \item{expected.label}{Used to customise failure messages. For expert
 use only.}
+
+\item{tolerance}{Non-negative scalar. For non-strict inequality comparisons,
+the supplied value is propagated to all.equal(). Defaults to 0.}
 }
 \description{
 Does code return a number greater/less than the expected value?

--- a/tests/testthat/test-expect-comparison.R
+++ b/tests/testthat/test-expect-comparison.R
@@ -35,6 +35,24 @@ test_that("comparisons with NA work", {
   expect_failure(expect_gte(NA_real_, NA_real_))
 })
 
+test_that("comparisons with tolerance work", {
+  expect_success(expect_lte(0, 0 - 1e-5, tolerance = 1e-5))
+  expect_success(expect_gte(0, 0 + 1e-7, tolerance = 1e-7))
+
+  expect_failure(expect_lte(0, 0 - 1.1e-5, tolerance = 1e-5))
+  expect_failure(expect_gte(0, 0 + 1.1e-7, tolerance = 1e-7))
+})
+
+test_that("tolerance is ignored for strict inequalities", {
+  pseudo_act <- list(val = 0)
+  pseudo_exp <- list(val = 1)
+
+  expect_message(
+    expect_compare("<", pseudo_act, pseudo_exp, tolerance = 1e-7),
+    "Tolerance \\(1e-07\\) will be ignored for operator '<'."
+  )
+})
+
 test_that("comparisons with more complicated objects work", {
   time <- Sys.time()
   time2 <- time + 1


### PR DESCRIPTION
Currently, the functions `expect_gte` and `expect_lte` have not implemented means to introduce a tolerance for the "equality" expectation part (as for example is done in `expect_equal(numeric(1), numeric(1))`.  However, in some cases it might be desirable to allow for a certain amount of tolerance. (Please excuse me and ignore this PR in case this possibility was already discussed and discarded in the past :see_no_evil: :v:)

In this PR, a possible solution is implemented that, for example in the `lte` case, substitutes (roughly speaking, see the changed code for actual implementation) `a <= b` with `a < b || all.equal(a, b, tol)`.


Issues/tbd:
- currently, it is assumed that `expect_lte(NA_real_, NA_real_)` fails. However, `all.equal(NA, NA)` usually evaluates to `TRUE`. This behavior is circumvented by the fact that once the first value is NULL or NA, the comparison shall never evaluate to `TRUE`.
- imo waldo comparison function for e3 are not required here, as the functions are for comparisons of length-1 vectors anyways

### Benchmarks

The changes would come at cost of a small decrease in speed, see the benchmark below (up to the maintaining developers to debate the significance :grimacing: :grinning: ) .

```r
library(devtools)
tmp_dir <- tempdir()
file.copy(".", tmp_dir, recursive = TRUE)
system(sprintf("cd %s && git checkout main", tmp_dir))

load_all(tmp_dir)
expect_compare_classic <- testthat:::expect_compare

load_all(".")
expect_compare_tol <- testthat:::expect_compare

ps_act <- list(val = 0)
ps_exp <- list(val = 1)

bench::mark(
  expect_compare_classic("<=", ps_act, ps_exp),
  expect_compare_tol("<=", ps_act, ps_exp)
)
```

**Results:**
```r
# A tibble: 2 x 13
  expression                                        min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result    memory                 time             gc                  
  <bch:expr>                                   <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list>    <list>                 <list>           <list>              
1 expect_compare_classic("<=", ps_act, ps_exp)   50.3µs   57.7µs    16882.        0B     34.0  7939    16      470ms <dbl [1]> <Rprofmem[,3] [0 × 3]> <bch:tm [7,955]> <tibble [7,955 × 3]>
2 expect_compare_tol("<=", ps_act, ps_exp)       78.7µs   89.3µs    10861.        0B     32.0  5089    15      469ms <dbl [1]> <Rprofmem[,3] [0 × 3]> <bch:tm [5,104]> <tibble [5,104 × 3]>
```

### Checklist

- [x] Tests have been adapted / added
- [x] PR description written
- [x] Documentation updated


