### PR TITLE
Update to rlang 1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,6 +56,8 @@ Suggests:
     xml2
 VignetteBuilder: 
     knitr
+Remotes:
+    r-lib/rlang
 Config/testthat/edition: 3
 Config/testthat/start-first: watcher, parallel*
 Config/Needs/website: tidyverse/tidytemplate

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Imports:
     R6 (>= 2.2.0),
     rlang (>= 0.4.9),
     utils,
-    waldo (>= 0.2.4),
+    waldo (>= 0.3.1),
     withr (>= 2.4.3)
 Suggests: 
     covr,

--- a/tests/testthat/_snaps/edition.md
+++ b/tests/testthat/_snaps/edition.md
@@ -2,6 +2,6 @@
 
     Code
       edition_deprecate(3, "old stuff")
-    Warning <warning>
+    Warning <rlang_warning>
       `old stuff` was deprecated in the 3rd edition.
 

--- a/tests/testthat/_snaps/reporter-check.md
+++ b/tests/testthat/_snaps/reporter-check.md
@@ -10,7 +10,8 @@
     -- Warning (tests.R:49:3): warnings get backtraces -----------------------------
     def
     Backtrace:
-     1. f() reporters/tests.R:49:2
+     1. f()
+          at reporters/tests.R:49:2
     
     == Failed tests ================================================================
     -- Failure (tests.R:12:3): Failure:1 -------------------------------------------
@@ -25,17 +26,17 @@
     `expected`: TRUE 
     Backtrace:
         x
-     1. \-f() reporters/tests.R:17:2
-     2.   \-testthat::expect_true(FALSE) reporters/tests.R:16:7
+     1. \-f() at reporters/tests.R:17:2
+     2.   \-testthat::expect_true(FALSE) at reporters/tests.R:16:7
     -- Error (tests.R:23:3): Error:1 -----------------------------------------------
     Error in `eval(code, test_env)`: stop
     -- Error (tests.R:31:3): errors get tracebacks ---------------------------------
     Error in `h()`: !
     Backtrace:
         x
-     1. \-f() reporters/tests.R:31:2
-     2.   \-g() reporters/tests.R:27:7
-     3.     \-h() reporters/tests.R:28:7
+     1. \-f() at reporters/tests.R:31:2
+     2.   \-g() at reporters/tests.R:27:7
+     3.     \-h() at reporters/tests.R:28:7
     
     [ FAIL 4 | WARN 1 | SKIP 3 | PASS 1 ]
 
@@ -65,7 +66,8 @@
     -- Warning (tests.R:49:3): warnings get backtraces -----------------------------
     def
     Backtrace:
-     1. f() reporters/tests.R:49:2
+     1. f()
+          at reporters/tests.R:49:2
     
     == Failed tests ================================================================
     -- Failure (tests.R:12:3): Failure:1 -------------------------------------------
@@ -80,17 +82,17 @@
     `expected`: TRUE 
     Backtrace:
         x
-     1. \-f() reporters/tests.R:17:2
-     2.   \-testthat::expect_true(FALSE) reporters/tests.R:16:7
+     1. \-f() at reporters/tests.R:17:2
+     2.   \-testthat::expect_true(FALSE) at reporters/tests.R:16:7
     -- Error (tests.R:23:3): Error:1 -----------------------------------------------
     Error in `eval(code, test_env)`: stop
     -- Error (tests.R:31:3): errors get tracebacks ---------------------------------
     Error in `h()`: !
     Backtrace:
         x
-     1. \-f() reporters/tests.R:31:2
-     2.   \-g() reporters/tests.R:27:7
-     3.     \-h() reporters/tests.R:28:7
+     1. \-f() at reporters/tests.R:31:2
+     2.   \-g() at reporters/tests.R:27:7
+     3.     \-h() at reporters/tests.R:28:7
     
     [ FAIL 4 | WARN 1 | SKIP 3 | PASS 1 ]
 

--- a/tests/testthat/_snaps/reporter-junit.md
+++ b/tests/testthat/_snaps/reporter-junit.md
@@ -19,7 +19,9 @@
     `expected`: TRUE 
     Backtrace:
      1. f()
-     2. testthat::expect_true(FALSE)</failure>
+          at reporters/tests.R:17:2
+     2. testthat::expect_true(FALSE)
+          at reporters/tests.R:16:7</failure>
         </testcase>
       </testsuite>
       <testsuite name="Errors" timestamp="1999:12:31 23:59:59" hostname="nodename" tests="2" skipped="0" failures="0" errors="2" time="0">
@@ -30,8 +32,11 @@
           <error type="error" message="Error in `h()`: ! (tests.R:31:3)">Error in `h()`: !
     Backtrace:
      1. f()
+          at reporters/tests.R:31:2
      2. g()
-     3. h()</error>
+          at reporters/tests.R:27:7
+     3. h()
+          at reporters/tests.R:28:7</error>
         </testcase>
       </testsuite>
       <testsuite name="Skips" timestamp="1999:12:31 23:59:59" hostname="nodename" tests="2" skipped="2" failures="0" errors="0" time="0">

--- a/tests/testthat/_snaps/reporter-progress.md
+++ b/tests/testthat/_snaps/reporter-progress.md
@@ -171,14 +171,13 @@
     | | 3       0 | reporters/backtraces                                            
     / | 4       0 | reporters/backtraces                                            
     - | 5       0 | reporters/backtraces                                            
-    \ | 5 1     0 | reporters/backtraces                                            
+    \ | 6       0 | reporters/backtraces                                            
     | | 6 1     0 | reporters/backtraces                                            
-    / | 6 2     0 | reporters/backtraces                                            
-    - | 6 2     1 | reporters/backtraces                                            
-    \ | 7 2     1 | reporters/backtraces                                            
-    | | 8 2     1 | reporters/backtraces                                            
-    / | 9 2     1 | reporters/backtraces                                            
-    x | 9 2     1 | reporters/backtraces
+    / | 6 1     1 | reporters/backtraces                                            
+    - | 7 1     1 | reporters/backtraces                                            
+    \ | 8 1     1 | reporters/backtraces                                            
+    | | 9 1     1 | reporters/backtraces                                            
+    x | 9 1     1 | reporters/backtraces
     --------------------------------------------------------------------------------
     Error (backtraces.R:6:3): errors thrown at block level are entraced
     Error in `g()`: foo
@@ -229,20 +228,6 @@
           at rlang/R/eval.R:96:2
      8. signaller()
           at reporters/backtraces.R:32:7
-    
-    Warning (backtraces.R:39:3): Errors are inspected with `conditionMessage()`
-    `scoped_bindings()` is deprecated as of rlang 0.4.2.
-    Please use `local_bindings()` instead.
-    This warning is displayed once per session.
-    Backtrace:
-     1. rlang::scoped_bindings(.env = globalenv(), conditionMessage.foobar = function(...) "dispatched")
-          at reporters/backtraces.R:39:2
-     2. rlang:::signal_soft_deprecated(...)
-          at rlang/R/lifecycle-deprecated.R:993:2
-     3. rlang:::warn_deprecated(msg, id)
-          at rlang/R/compat-lifecycle.R:104:4
-     4. base .Signal(msg = msg)
-          at rlang/R/compat-lifecycle.R:149:2
     
     Error (backtraces.R:43:3): Errors are inspected with `conditionMessage()`
     <foobar/rlang_error/error/condition>
@@ -314,7 +299,7 @@
     --------------------------------------------------------------------------------
     
     == Results =====================================================================
-    [ FAIL 9 | WARN 2 | SKIP 0 | PASS 1 ]
+    [ FAIL 9 | WARN 1 | SKIP 0 | PASS 1 ]
     
     I believe in you!
 

--- a/tests/testthat/_snaps/reporter-progress.md
+++ b/tests/testthat/_snaps/reporter-progress.md
@@ -9,10 +9,14 @@
     Error (error-setup.R:6:1): (code run outside of `test_that()`)
     Error in `h()`: !
     Backtrace:
-     1. testthat::setup(f()) reporters/error-setup.R:6:0
+     1. testthat::setup(f())
+          at reporters/error-setup.R:6:0
      3. f()
-     4. g() reporters/error-setup.R:1:5
-     5. h() reporters/error-setup.R:2:5
+          at rlang/R/eval-tidy.R:121:2
+     4. g()
+          at reporters/error-setup.R:1:5
+     5. h()
+          at reporters/error-setup.R:2:5
     --------------------------------------------------------------------------------
     
     == Results =====================================================================
@@ -167,83 +171,116 @@
     | | 3       0 | reporters/backtraces                                            
     / | 4       0 | reporters/backtraces                                            
     - | 5       0 | reporters/backtraces                                            
-    \ | 6       0 | reporters/backtraces                                            
+    \ | 5 1     0 | reporters/backtraces                                            
     | | 6 1     0 | reporters/backtraces                                            
-    / | 6 1     1 | reporters/backtraces                                            
-    - | 7 1     1 | reporters/backtraces                                            
-    \ | 8 1     1 | reporters/backtraces                                            
-    | | 9 1     1 | reporters/backtraces                                            
-    x | 9 1     1 | reporters/backtraces
+    / | 6 2     0 | reporters/backtraces                                            
+    - | 6 2     1 | reporters/backtraces                                            
+    \ | 7 2     1 | reporters/backtraces                                            
+    | | 8 2     1 | reporters/backtraces                                            
+    / | 9 2     1 | reporters/backtraces                                            
+    x | 9 2     1 | reporters/backtraces
     --------------------------------------------------------------------------------
     Error (backtraces.R:6:3): errors thrown at block level are entraced
     Error in `g()`: foo
     Backtrace:
-     1. f() reporters/backtraces.R:6:2
-     2. g() reporters/backtraces.R:4:7
+     1. f()
+          at reporters/backtraces.R:6:2
+     2. g()
+          at reporters/backtraces.R:4:7
     
     Error (backtraces.R:11:3): errors thrown from a quasi-labelled argument are entraced
     Error in `foo()`: foo
     Backtrace:
-     1. testthat::expect_s3_class(foo(), "foo") reporters/backtraces.R:11:2
+     1. testthat::expect_s3_class(foo(), "foo")
+          at reporters/backtraces.R:11:2
      4. foo()
+          at rlang/R/eval.R:96:2
     
     Error (backtraces.R:18:3): errors thrown from a quasi-labelled argument are entraced (deep case)
     Error in `foo()`: foo
     Backtrace:
-     1. testthat::expect_s3_class(f(), "foo") reporters/backtraces.R:18:2
+     1. testthat::expect_s3_class(f(), "foo")
+          at reporters/backtraces.R:18:2
      4. f()
-     5. g() reporters/backtraces.R:16:7
+          at rlang/R/eval.R:96:2
+     5. g()
+          at reporters/backtraces.R:16:7
      9. foo()
+          at rlang/R/eval.R:96:2
     
     Error (backtraces.R:28:3): errors thrown from a quasi-labelled argument are entraced (deep deep case)
     Error in `bar()`: foobar
     Backtrace:
-     1. f() reporters/backtraces.R:28:2
-     2. g() reporters/backtraces.R:25:7
+     1. f()
+          at reporters/backtraces.R:28:2
+     2. g()
+          at reporters/backtraces.R:25:7
      6. foo()
-     7. bar() reporters/backtraces.R:22:9
+          at rlang/R/eval.R:96:2
+     7. bar()
+          at reporters/backtraces.R:22:9
     
     Error (backtraces.R:35:3): failed expect_error() prints a backtrace
     Error in `signaller()`: bar
     Backtrace:
-     1. testthat::expect_error(f(), "foo") reporters/backtraces.R:35:2
+     1. testthat::expect_error(f(), "foo")
+          at reporters/backtraces.R:35:2
      7. f()
-     8. signaller() reporters/backtraces.R:32:7
+          at rlang/R/eval.R:96:2
+     8. signaller()
+          at reporters/backtraces.R:32:7
+    
+    Warning (backtraces.R:39:3): Errors are inspected with `conditionMessage()`
+    `scoped_bindings()` is deprecated as of rlang 0.4.2.
+    Please use `local_bindings()` instead.
+    This warning is displayed once per session.
+    Backtrace:
+     1. rlang::scoped_bindings(.env = globalenv(), conditionMessage.foobar = function(...) "dispatched")
+          at reporters/backtraces.R:39:2
+     2. rlang:::signal_soft_deprecated(...)
+          at rlang/R/lifecycle-deprecated.R:993:2
+     3. rlang:::warn_deprecated(msg, id)
+          at rlang/R/compat-lifecycle.R:104:4
+     4. base .Signal(msg = msg)
+          at rlang/R/compat-lifecycle.R:149:2
     
     Error (backtraces.R:43:3): Errors are inspected with `conditionMessage()`
     <foobar/rlang_error/error/condition>
-    Error: dispatched
+    Error in `eval(code, test_env)`: dispatched
+    Backtrace:
     
     Warning (backtraces.R:50:3): also get backtraces for warnings
     foobar
     Backtrace:
-     1. foo() reporters/backtraces.R:50:2
-     2. bar() reporters/backtraces.R:47:9
+     1. foo()
+          at reporters/backtraces.R:50:2
+     2. bar()
+          at reporters/backtraces.R:47:9
     
     Error (backtraces.R:58:3): deep stacks are trimmed
     Error in `f(x - 1)`: This is deep
     Backtrace:
-      1. f(25) reporters/backtraces.R:58:2
-      2. f(x - 1) reporters/backtraces.R:56:4
-      3. f(x - 1) reporters/backtraces.R:56:4
-      4. f(x - 1) reporters/backtraces.R:56:4
-      5. f(x - 1) reporters/backtraces.R:56:4
-      6. f(x - 1) reporters/backtraces.R:56:4
-      7. f(x - 1) reporters/backtraces.R:56:4
-      8. f(x - 1) reporters/backtraces.R:56:4
-      9. f(x - 1) reporters/backtraces.R:56:4
-     10. f(x - 1) reporters/backtraces.R:56:4
+      1. f(25)
+           at reporters/backtraces.R:58:2
+      2. f(x - 1)
+           at reporters/backtraces.R:56:4
+      3. f(x - 1)
+           at reporters/backtraces.R:56:4
+      4. f(x - 1)
+           at reporters/backtraces.R:56:4
+      5. f(x - 1)
+           at reporters/backtraces.R:56:4
          ...
-     17. f(x - 1) reporters/backtraces.R:56:4
-     18. f(x - 1) reporters/backtraces.R:56:4
-     19. f(x - 1) reporters/backtraces.R:56:4
-     20. f(x - 1) reporters/backtraces.R:56:4
-     21. f(x - 1) reporters/backtraces.R:56:4
-     22. f(x - 1) reporters/backtraces.R:56:4
-     23. f(x - 1) reporters/backtraces.R:56:4
-     24. f(x - 1) reporters/backtraces.R:56:4
-     25. f(x - 1) reporters/backtraces.R:56:4
-     26. f(x - 1) reporters/backtraces.R:56:4
+     22. f(x - 1)
+           at reporters/backtraces.R:56:4
+     23. f(x - 1)
+           at reporters/backtraces.R:56:4
+     24. f(x - 1)
+           at reporters/backtraces.R:56:4
+     25. f(x - 1)
+           at reporters/backtraces.R:56:4
+     26. f(x - 1)
+           at reporters/backtraces.R:56:4
     
     Failure (backtraces.R:66:1): (code run outside of `test_that()`)
     FALSE is not TRUE
@@ -251,10 +288,14 @@
     `actual`:   FALSE
     `expected`: TRUE 
     Backtrace:
-     1. f() reporters/backtraces.R:66:0
-     2. g() reporters/backtraces.R:62:5
-     3. h() reporters/backtraces.R:63:5
-     4. testthat::expect_true(FALSE) reporters/backtraces.R:64:5
+     1. f()
+          at reporters/backtraces.R:66:0
+     2. g()
+          at reporters/backtraces.R:62:5
+     3. h()
+          at reporters/backtraces.R:63:5
+     4. testthat::expect_true(FALSE)
+          at reporters/backtraces.R:64:5
     
     Failure (backtraces.R:69:3): nested expectations get backtraces
     FALSE is not TRUE
@@ -262,14 +303,18 @@
     `actual`:   FALSE
     `expected`: TRUE 
     Backtrace:
-     1. f() reporters/backtraces.R:69:2
-     2. g() reporters/backtraces.R:62:5
-     3. h() reporters/backtraces.R:63:5
-     4. testthat::expect_true(FALSE) reporters/backtraces.R:64:5
+     1. f()
+          at reporters/backtraces.R:69:2
+     2. g()
+          at reporters/backtraces.R:62:5
+     3. h()
+          at reporters/backtraces.R:63:5
+     4. testthat::expect_true(FALSE)
+          at reporters/backtraces.R:64:5
     --------------------------------------------------------------------------------
     
     == Results =====================================================================
-    [ FAIL 9 | WARN 1 | SKIP 0 | PASS 1 ]
+    [ FAIL 9 | WARN 2 | SKIP 0 | PASS 1 ]
     
     I believe in you!
 
@@ -324,7 +369,9 @@
     `expected`: TRUE 
     Backtrace:
      1. f()
+          at reporters/tests.R:17:2
      2. testthat::expect_true(FALSE)
+          at reporters/tests.R:16:7
     
     
     [ FAIL 2 | WARN 0 | SKIP 0 | PASS 1 ]
@@ -338,8 +385,11 @@
     Error in `h()`: !
     Backtrace:
      1. f()
+          at reporters/tests.R:31:2
      2. g()
+          at reporters/tests.R:27:7
      3. h()
+          at reporters/tests.R:28:7
     
     
     [ FAIL 4 | WARN 0 | SKIP 0 | PASS 1 ]
@@ -360,7 +410,8 @@
     -- Warning (tests.R:49:3): warnings get backtraces -----------------------------
     def
     Backtrace:
-     1. f() reporters/tests.R:49:2
+     1. f()
+          at reporters/tests.R:49:2
     
     -- Skip (tests.R:45:1): warnings get backtraces --------------------------------
     Reason: empty test

--- a/tests/testthat/_snaps/reporter-stop.md
+++ b/tests/testthat/_snaps/reporter-stop.md
@@ -14,7 +14,9 @@
     `expected`: TRUE 
     Backtrace:
      1. f()
+          at reporters/tests.R:17:2
      2. testthat::expect_true(FALSE)
+          at reporters/tests.R:16:7
     
     -- Error (tests.R:23:3): Error:1 -----------------------------------------------
     Error in `eval(code, test_env)`: stop
@@ -23,8 +25,11 @@
     Error in `h()`: !
     Backtrace:
      1. f()
+          at reporters/tests.R:31:2
      2. g()
+          at reporters/tests.R:27:7
      3. h()
+          at reporters/tests.R:28:7
     
     -- Skip (tests.R:37:3): explicit skips are reported ----------------------------
     Reason: skip
@@ -36,6 +41,7 @@
     def
     Backtrace:
      1. f()
+          at reporters/tests.R:49:2
     
     -- Skip (tests.R:45:1): warnings get backtraces --------------------------------
     Reason: empty test

--- a/tests/testthat/_snaps/reporter-summary.md
+++ b/tests/testthat/_snaps/reporter-summary.md
@@ -30,8 +30,10 @@
     `actual`:   FALSE
     `expected`: TRUE 
     Backtrace:
-     1. f() reporters/tests.R:17:2
-     2. testthat::expect_true(FALSE) reporters/tests.R:16:7
+     1. f()
+          at reporters/tests.R:17:2
+     2. testthat::expect_true(FALSE)
+          at reporters/tests.R:16:7
     
     -- 3. Error (tests.R:23:3): Error:1 --------------------------------------------
     Error in `eval(code, test_env)`: stop
@@ -39,9 +41,12 @@
     -- 4. Error (tests.R:31:3): errors get tracebacks ------------------------------
     Error in `h()`: !
     Backtrace:
-     1. f() reporters/tests.R:31:2
-     2. g() reporters/tests.R:27:7
-     3. h() reporters/tests.R:28:7
+     1. f()
+          at reporters/tests.R:31:2
+     2. g()
+          at reporters/tests.R:27:7
+     3. h()
+          at reporters/tests.R:28:7
     
     == DONE ========================================================================
 
@@ -77,8 +82,10 @@
     `actual`:   FALSE
     `expected`: TRUE 
     Backtrace:
-     1. f() reporters/tests.R:17:2
-     2. testthat::expect_true(FALSE) reporters/tests.R:16:7
+     1. f()
+          at reporters/tests.R:17:2
+     2. testthat::expect_true(FALSE)
+          at reporters/tests.R:16:7
     
     -- 3. Error (tests.R:23:3): Error:1 --------------------------------------------
     Error in `eval(code, test_env)`: stop
@@ -86,9 +93,12 @@
     -- 4. Error (tests.R:31:3): errors get tracebacks ------------------------------
     Error in `h()`: !
     Backtrace:
-     1. f() reporters/tests.R:31:2
-     2. g() reporters/tests.R:27:7
-     3. h() reporters/tests.R:28:7
+     1. f()
+          at reporters/tests.R:31:2
+     2. g()
+          at reporters/tests.R:27:7
+     3. h()
+          at reporters/tests.R:28:7
     
     == DONE ========================================================================
 
@@ -124,8 +134,10 @@
     `actual`:   FALSE
     `expected`: TRUE 
     Backtrace:
-     1. f() reporters/tests.R:17:2
-     2. testthat::expect_true(FALSE) reporters/tests.R:16:7
+     1. f()
+          at reporters/tests.R:17:2
+     2. testthat::expect_true(FALSE)
+          at reporters/tests.R:16:7
       ... and 2 more
     
     

--- a/tests/testthat/_snaps/reporter-tap.md
+++ b/tests/testthat/_snaps/reporter-tap.md
@@ -15,23 +15,29 @@
       `actual`:   FALSE
       `expected`: TRUE 
       Backtrace:
-       1. f() reporters/tests.R:17:2
-       2. testthat::expect_true(FALSE) reporters/tests.R:16:7
+       1. f()
+            at reporters/tests.R:17:2
+       2. testthat::expect_true(FALSE)
+            at reporters/tests.R:16:7
     # Context Errors
     not ok 4 Error:1
       Error in `eval(code, test_env)`: stop
     not ok 5 errors get tracebacks
       Error in `h()`: !
       Backtrace:
-       1. f() reporters/tests.R:31:2
-       2. g() reporters/tests.R:27:7
-       3. h() reporters/tests.R:28:7
+       1. f()
+            at reporters/tests.R:31:2
+       2. g()
+            at reporters/tests.R:27:7
+       3. h()
+            at reporters/tests.R:28:7
     # Context Skips
     ok 6 # SKIP Reason: skip
     ok 7 # SKIP Reason: empty test
     # Context Warnings
     ok 8 # WARNING def
     Backtrace:
-     1. f() reporters/tests.R:49:2
+     1. f()
+          at reporters/tests.R:49:2
     ok 9 # SKIP Reason: empty test
 

--- a/tests/testthat/_snaps/reporter-teamcity.md
+++ b/tests/testthat/_snaps/reporter-teamcity.md
@@ -18,7 +18,7 @@
     
     ##teamcity[testSuiteStarted name='Failure:2a']
     ##teamcity[testStarted name='expectation 1']
-    ##teamcity[testFailed name='expectation 1' message='FALSE is not TRUE' details='|n`actual`:   FALSE|n`expected`: TRUE |nBacktrace:|n 1. f()|n 2. testthat::expect_true(FALSE)']
+    ##teamcity[testFailed name='expectation 1' message='FALSE is not TRUE' details='|n`actual`:   FALSE|n`expected`: TRUE |nBacktrace:|n 1. f()|n      at reporters/tests.R:17:2|n 2. testthat::expect_true(FALSE)|n      at reporters/tests.R:16:7']
     ##teamcity[testFinished name='expectation 1']
     ##teamcity[testSuiteFinished name='Failure:2a']
     
@@ -34,7 +34,7 @@
     
     ##teamcity[testSuiteStarted name='errors get tracebacks']
     ##teamcity[testStarted name='expectation 1']
-    ##teamcity[testFailed name='expectation 1' message='Error in `h()`: !' details='Backtrace:|n 1. f()|n 2. g()|n 3. h()']
+    ##teamcity[testFailed name='expectation 1' message='Error in `h()`: !' details='Backtrace:|n 1. f()|n      at reporters/tests.R:31:2|n 2. g()|n      at reporters/tests.R:27:7|n 3. h()|n      at reporters/tests.R:28:7']
     ##teamcity[testFinished name='expectation 1']
     ##teamcity[testSuiteFinished name='errors get tracebacks']
     

--- a/tests/testthat/_snaps/rlang-1.0/snapshot.md
+++ b/tests/testthat/_snaps/rlang-1.0/snapshot.md
@@ -5,9 +5,9 @@
       abort("Title.", parent = foo)
     Condition
       Error:
-        Title.
+      ! Title.
       Caused by error:
-        Title parent.
+      ! Title parent.
 
 # can print with and without condition classes
 
@@ -16,9 +16,11 @@
     Message <simpleMessage>
       foo
     Condition <simpleWarning>
-      Warning in `f()`: bar
+      Warning in `f()`:
+      bar
     Condition <simpleError>
-      Error in `f()`: baz
+      Error in `f()`:
+      ! baz
 
 ---
 
@@ -27,14 +29,18 @@
     Message
       foo
     Condition
-      Warning in `f()`: bar
-      Error in `f()`: baz
+      Warning in `f()`:
+      bar
+      Error in `f()`:
+      ! baz
 
 # errors and warnings are folded
 
     Code
       f()
     Condition
-      Warning in `f()`: foo
-      Error in `f()`: bar
+      Warning in `f()`:
+      foo
+      Error in `f()`:
+      ! bar
 

--- a/tests/testthat/_snaps/snapshot-cleanup.md
+++ b/tests/testthat/_snaps/snapshot-cleanup.md
@@ -2,7 +2,7 @@
 
     Code
       snapshot_cleanup(dir)
-    Message <message>
+    Message <rlang_message>
       Deleting unused snapshots:
       * a.md
       * b.md

--- a/tests/testthat/_snaps/snapshot-manage.md
+++ b/tests/testthat/_snaps/snapshot-manage.md
@@ -2,7 +2,7 @@
 
     Code
       snapshot_accept(path = path)
-    Message <message>
+    Message <rlang_message>
       Updating snapshots:
       * a.md
       * b.md
@@ -11,14 +11,14 @@
 
     Code
       snapshot_accept(path = path)
-    Message <message>
+    Message <rlang_message>
       No snapshots to update
 
 # can accept specific files
 
     Code
       snapshot_accept("a", path = path)
-    Message <message>
+    Message <rlang_message>
       Updating snapshots:
       * a.md
 
@@ -26,7 +26,7 @@
 
     Code
       snapshot_accept("test/a.txt", path = path)
-    Message <message>
+    Message <rlang_message>
       Updating snapshots:
       * test/a.txt
 
@@ -34,7 +34,7 @@
 
     Code
       snapshot_accept("test/", path = path)
-    Message <message>
+    Message <rlang_message>
       Updating snapshots:
       * test/a.txt
 
@@ -42,7 +42,7 @@
 
     Code
       snapshot_accept(path = path)
-    Message <message>
+    Message <rlang_message>
       Updating snapshots:
       * foo/a.md
 
@@ -50,7 +50,7 @@
 
     Code
       snapshot_accept("foo/a", path = path)
-    Message <message>
+    Message <rlang_message>
       Updating snapshots:
       * foo/a.md
 

--- a/tests/testthat/reporters/backtraces.R
+++ b/tests/testthat/reporters/backtraces.R
@@ -36,7 +36,7 @@ test_that("failed expect_error() prints a backtrace", {
 })
 
 test_that("Errors are inspected with `conditionMessage()`", {
-  rlang::scoped_bindings(
+  rlang::local_bindings(
     .env = globalenv(),
     conditionMessage.foobar = function(...) "dispatched"
   )

--- a/tests/testthat/test-reporter-progress.R
+++ b/tests/testthat/test-reporter-progress.R
@@ -1,4 +1,7 @@
 test_that("captures error before first test", {
+  # Backtrace srcrefs failure
+  skip_on_covr()
+
   local_output_override()
 
   expect_snapshot_reporter(
@@ -43,6 +46,9 @@ test_that("can fully suppress incremental updates", {
 })
 
 test_that("reports backtraces", {
+  # Avoid failures because of different srcrefs in backtraces
+  skip_on_covr()
+
   expect_snapshot_reporter(
     ProgressReporter$new(update_interval = 0, min_time = Inf),
     test_path("reporters/backtraces.R")

--- a/tests/testthat/test-verify-output.R
+++ b/tests/testthat/test-verify-output.R
@@ -13,7 +13,7 @@ test_that("can record all types of output", {
 })
 
 test_that("can record all types of output", {
-  scoped_bindings(
+  local_bindings(
     .env = global_env(),
     conditionMessage.foobar = function(cnd) {
       paste("Dispatched!", cnd$message)


### PR DESCRIPTION
Update snapshots and use `local_bindings()` instead of deprecated `scoped_bindings()` function.

I've added a remote to dev rlang because the callr test in https://github.com/r-lib/testthat/blob/main/tests/testthat/test-parallel-crash.R fails with CRAN rlang. It is fixed by this commit: https://github.com/r-lib/rlang/commit/c84d52b6f01aaad98adfc57c29bca64a655f636e. This won't get in the way of a testthat patch release because this test is skipped on CRAN.