### PR TITLE
Explain the deal w/ expect_snapshot_error() vs. expect_snapshot(error…

### DIFF
--- a/vignettes/snapshotting.Rmd
+++ b/vignettes/snapshotting.Rmd
@@ -214,6 +214,8 @@ test_that("you can't add weird thngs", {
 
 `expect_snapshot()` is the most used snapshot function because it records everything: the code you run, printed output, messages, warnings, and errors.
 But sometimes you just want to capture the output or errors in which you might want to use `expect_snapshot_output()` or `expect_snapshot_error()`.
+This can happen when the associated code is lengthy or doesn't add much in terms of capturing the test's intent.
+`expect_snapshot_error()` predates `expect_snapshot()` and, if history had unfolded differently, `expect_snapshot(error = TRUE, ...)` probably would have made `expect_snapshot_error()` unnecessary.
 
 Or rather than caring about side-effects, you may want to check that the value of an R object stays the same.
 In this case, you can use `expect_snapshot_value()` which offers a number of serialisation approaches that provide a tradeoff between accuracy and human readability.


### PR DESCRIPTION
… = TRUE)

Related to getting stuff out of my head and/or out of the (revised) testing chapter in R Packages.

I've needed to be reminded of this multiple times now.