### PR TITLE
set local state for detecting default edition

### DIFF
--- a/tests/testthat/test-edition.R
+++ b/tests/testthat/test-edition.R
@@ -29,6 +29,7 @@ test_that("edition for testthat is 3", {
 })
 
 test_that("edition for non-package dir is 2", {
+  withr::local_envvar(TESTTHAT_EDITION = NULL)
   expect_equal(find_edition(tempdir()), 2)
 })
 


### PR DESCRIPTION
If the test suite is run in an environment where `TESTTHAT_EDITION=3` is set, this test will fail; reset that locally to ensure success