### PR TITLE
Improve check for $srcref member in expectation

### DIFF
--- a/R/expectation.R
+++ b/R/expectation.R
@@ -257,7 +257,7 @@ single_letter_summary <- function(x) {
 }
 
 expectation_location <- function(x) {
-  if (is.null(x$srcref)) {
+  if (!inherits(x$srcref, "srcref")) {
     "???"
   } else {
     srcfile <- attr(x$srcref, "srcfile")


### PR DESCRIPTION
Otherwise if the original error object has a $srcref member that is
not of the srcref class then testthat fails when reporting the error.