### PR TITLE
Avoid defining the visibility attribute on Windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # testthat (development version)
 
+* Fixed a warning in R >=4.2.0 on Windows that occurred when using the C++
+  testing infrastructure that testthat provides (#1672).
+
 * You can now configure the behaviour of the implicit
   `devtools::load_all()` call performed by `devtools::test()` in your
   package DESCRIPTION file (#1636). To disable exports of internal

--- a/inst/include/testthat/testthat.h
+++ b/inst/include/testthat/testthat.h
@@ -12,16 +12,9 @@
  * Force 'testthat' to be disabled by defining TESTTHAT_DISABLED.
  * TESTTHAT_DISABLED takes precedence.
  * 'testthat' is disabled on Solaris by default.
- *
- * Hide symbols containing static members on gcc, to work around issues
- * with DLL unload due to static members in inline functions.
- * https://github.com/r-lib/devtools/issues/1832
  */
 #if defined(__GNUC__) || defined(__clang__)
 # define TESTTHAT_ENABLED
-# define TESTTHAT_ATTRIBUTE_HIDDEN __attribute__ ((visibility("hidden")))
-#else
-# define TESTTHAT_ATTRIBUTE_HIDDEN
 #endif
 
 #if defined(__SUNPRO_C) || defined(__SUNPRO_CC) || defined(__sun) || defined(__SVR4)
@@ -30,6 +23,20 @@
 
 #ifndef TESTTHAT_ENABLED
 # define TESTTHAT_DISABLED
+#endif
+
+/*
+ * Hide symbols containing static members on gcc, to work around issues
+ * with DLL unload due to static members in inline functions. This seems to only
+ * affect Linux. We never define this attribute on Windows, as MinGW has a known
+ * issue with this visibility attribute and ignores it with a warning.
+ * https://github.com/r-lib/devtools/issues/1832
+ * https://github.com/r-lib/testthat/issues/1672
+ */
+#if (defined(__GNUC__) && !defined(__MINGW32__)) || defined(__clang__)
+# define TESTTHAT_ATTRIBUTE_HIDDEN __attribute__ ((visibility("hidden")))
+#else
+# define TESTTHAT_ATTRIBUTE_HIDDEN
 #endif
 
 #ifndef TESTTHAT_DISABLED


### PR DESCRIPTION
Closes #1672 , see that issue for my full description of the problem.

Confirmed that the warning in the `windows-latest (release)` GitHub Actions workflow of this cpp11 PR disappeared when I added a remote on this testthat PR https://github.com/r-lib/cpp11/pull/279/commits/d15902a74c4e54e947926f6d6e2af6a97ea910eb