### PR TITLE
Skip local_language() when LANG='C' is set

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,9 +6,9 @@
   (@kevinushey, #1687)
 
 * `local_reproducible_output` will no longer attempt to set the local language
-  when an R version is used that was not compiled with natural language support
-  (NLS), which would previously emit non-test-related warnings during testing
-  (@dgkf, #1662).
+  when `LANG='C'` is set or an R version is used that was not compiled with
+  natural language support (NLS), which would previously emit non-test-related
+  warnings during testing (@dgkf, #1662; @heavywatal, #1689).
 
 * New `set_max_fails()` helper to make it easier to set the maximum number of
   failures before stopping the test suite. And the advice to set to Inf is

--- a/R/local.R
+++ b/R/local.R
@@ -118,7 +118,7 @@ local_reproducible_output <- function(width = 80,
   )
   withr::local_envvar(RSTUDIO = NA, .local_envir = .env)
 
-  if (isTRUE(capabilities("NLS"))) {
+  if (isTRUE(capabilities("NLS")) && Sys.getenv("LANG") != "C") {
     withr::local_language(lang, .local_envir = .env)
   }
 


### PR DESCRIPTION
Fixes #1563.
This is a minor addition to #1662.