### PR TITLE
don't pass 'rng' to random_shuffle

### DIFF
--- a/inst/include/testthat/vendor/catch.h
+++ b/inst/include/testthat/vendor/catch.h
@@ -7184,7 +7184,7 @@ namespace Catch {
             std::mt19937 rng( device() );
             std::shuffle( vector.begin(), vector.end(), rng );
 #else
-            random_shuffle( vector.begin(), vector.end(), rng );
+            random_shuffle( vector.begin(), vector.end() );
 #endif
         }
     };

--- a/inst/include/testthat/vendor/catch.h
+++ b/inst/include/testthat/vendor/catch.h
@@ -7184,7 +7184,7 @@ namespace Catch {
             std::mt19937 rng( device() );
             std::shuffle( vector.begin(), vector.end(), rng );
 #else
-            random_shuffle( vector.begin(), vector.end() );
+            std::random_shuffle( vector.begin(), vector.end() );
 #endif
         }
     };


### PR DESCRIPTION
Closes https://github.com/r-lib/testthat/issues/1694.