### PR TITLE
Remap `sprintf` to `Rprintf`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: testthat
 Title: Unit Testing for R
-Version: 3.1.5.9000
+Version: 3.1.6
 Authors@R: c(
     person("Hadley", "Wickham", , "hadley@rstudio.com", role = c("aut", "cre")),
     person("RStudio", role = c("cph", "fnd")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
-# testthat (development version)
+# testthat 3.1.6
+
+* Fixed CRAN warning about usage of `sprintf()` in `Catch.h` (#1715).
+
 
 # testthat 3.1.5
 

--- a/inst/include/testthat/testthat.h
+++ b/inst/include/testthat/testthat.h
@@ -69,11 +69,17 @@ inline int rand() { return 42; }
 inline void exit(int) throw() {}
 
 }
-# include "vendor/catch.h"
 
 // Implement an output stream that avoids writing to stdout / stderr.
+// See also https://github.com/r-lib/testthat/issues/1715.
 extern "C" void Rprintf(const char*, ...);
 extern "C" void R_FlushConsole();
+
+# include <cstdio>
+# define sprintf Rprintf
+# define sprintf_s Rprintf
+
+# include "vendor/catch.h"
 
 namespace testthat {
 


### PR DESCRIPTION
Fix for https://github.com/wch/r-source/commit/a0dfa3df365e3ee2b4496fc2374963ff20da7043 which causes this warning on our CRAN checks as well as in packages that include `inst/testthat.h`:

```
Version: 3.1.5
Check: compiled code
Result: WARN
    File 'testthat/libs/testthat.so':
     Found 'sprintf', possibly from 'sprintf' (C)
     Object: 'test-runner.o'
    
    Compiled code should not call entry points which might terminate R nor
    write to stdout/stderr instead of to the console, nor use Fortran I/O
    nor system RNGs nor [v]sprintf.
    
    See 'Writing portable packages' in the 'Writing R Extensions' manual.
Flavors: [r-devel-linux-x86_64-debian-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/testthat-00check.html), [r-devel-linux-x86_64-fedora-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-clang/testthat-00check.html)
```

Bumps version to 3.1.6 for a patch release.
Closes #1715.