### PR TITLE
Add the column back to the `expectation_location()`.

### DIFF
--- a/R/expectation.R
+++ b/R/expectation.R
@@ -265,7 +265,7 @@ expectation_location <- function(x) {
     if (identical(filename, "")) {
       paste0("Line ", x$srcref[1])
     } else {
-      cli::format_inline("{.file {filename}:{x$srcref[1]}}")
+      cli::format_inline("{.file {filename}:{x$srcref[1]}:{x$srcref[2]}}")
     }
   }
 }


### PR DESCRIPTION
was removed in https://github.com/r-lib/testthat/pull/1686
related to https://github.com/rstudio/rstudio/pull/12431

cc @DavisVaughan 