### PR TITLE
Include the "Manage test reporting" article in the Reporters block.

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -62,6 +62,7 @@ reference:
 
 - title: Reporters
   contents:
+  - Reporter
   - ends_with("Reporter")
 
 - title: Expectation internals


### PR DESCRIPTION
Evidently "Reporter" doesn't qualify as `ends_with("Reporter")` when pkgdown builds the site. This leads to confusing documentation that doesn't describe what a Reporter is in general.

This made the [Reporters](https://testthat.r-lib.org/reference/index.html#reporters) section of the reference difficult to follow at first.
