### PR TITLE
Use cat() to avoid cli wrapping

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # testthat (development version)
 
+* `expect_snapshot()` no longer elides new lines when run interactively (#1726).
+
 * Experimental new `with_mocked_bindings()` and `local_mocked_bindings()` 
   (#1739).
 

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -426,9 +426,9 @@ snapshot_accept_hint <- function(variant, file, reset_output = TRUE) {
 snapshot_not_available <- function(message) {
   cli::cli_inform(c(
     "{.strong Can't compare snapshot to reference when testing interactively.}",
-    i = "Run {.run devtools::test()} or {.code testthat::test_file()} to see changes.",
-    i = message
+    i = "Run {.run devtools::test()} or {.code testthat::test_file()} to see changes."
   ))
+  cat(message, "\n", sep = "")
 }
 
 local_snapshot_dir <- function(snap_names, .env = parent.frame()) {

--- a/tests/testthat/test-snapshot-reporter.R
+++ b/tests/testthat/test-snapshot-reporter.R
@@ -13,7 +13,9 @@ test_that("basic workflow", {
   snapper <- local_snapshotter(path)
   snapper$start_file("snapshot-2")
   # output if not active (because test not set here)
-  expect_message(expect_snapshot_output("x"), "Can't compare")
+  expect_snapshot_output("x") |>
+    expect_message("Can't compare") |>
+    expect_output("Current value:\n[1] \"x\"", fixed = TRUE)
 
   # warns on first creation
   snapper$start_file("snapshot-2", "test")

--- a/tests/testthat/test-snapshot-reporter.R
+++ b/tests/testthat/test-snapshot-reporter.R
@@ -13,8 +13,8 @@ test_that("basic workflow", {
   snapper <- local_snapshotter(path)
   snapper$start_file("snapshot-2")
   # output if not active (because test not set here)
-  expect_snapshot_output("x") |>
-    expect_message("Can't compare") |>
+  expect_snapshot_output("x") %>%
+    expect_message("Can't compare") %>%
     expect_output("Current value:\n[1] \"x\"", fixed = TRUE)
 
   # warns on first creation


### PR DESCRIPTION
Fixes #1726