### PR TITLE
Add alt-text to logo in README and images in snapshot vignette

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -12,7 +12,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-# testthat <img src="man/figures/logo.png" align="right" />
+# testthat <img src="man/figures/logo.png" align="right" alt=""/>
 
 <!-- badges: start -->
 [![CRAN status](https://www.r-pkg.org/badges/version/testthat)](https://cran.r-project.org/package=testthat)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# testthat <img src="man/figures/logo.png" align="right" />
+# testthat <img src="man/figures/logo.png" align="right" alt=""/>
 
 <!-- badges: start -->
 

--- a/vignettes/snapshotting.Rmd
+++ b/vignettes/snapshotting.Rmd
@@ -238,7 +238,23 @@ Unlike `expect_snapshot()` and friends, `expect_snapshot_file()` can't provide a
 Instead you'll need to call `snapshot_review()`.
 This launches a Shiny app that allows you to visually review each change and approve it if it's deliberate:
 
-![](review-image.png) ![](review-text.png)
+```{r}
+#| echo: false
+#| fig-alt: Screenshot of the Shiny app for reviewing snapshot
+#|     changes to images. It shows the changes to a png file of 
+#|     a plot created in a snapshot test. There is a button 
+#|     to accept the changed snapshot, or to skip it.
+knitr::include_graphics("review-image.png")
+```
+
+```{r}
+#| echo: false
+#| fig-alt: Screenshot of the Shiny app for reviewing snapshot
+#|     changes to text files. It shows the changes to a .R file 
+#|     created in a snapshot test, where a line has been removed. 
+#|     There is a button to accept the changed snapshot, or to skip it.
+knitr::include_graphics("review-text.png")
+```
 
 The display varies based on the file type (currently text files, common image files, and csv files are supported).
 


### PR DESCRIPTION
Partially addresses #1749 