### PR TITLE
Clarify argument names in `test_files_setup_state()`

### DIFF
--- a/R/parallel.R
+++ b/R/parallel.R
@@ -227,7 +227,7 @@ queue_process_setup <- function(test_package, test_dir, load_helpers, load_packa
     test_package = test_package,
     load_helpers = load_helpers,
     env = env,
-    .env = .GlobalEnv
+    exit_frame = .GlobalEnv
   )
 
   # Save test environment in global env where it can easily be retrieved

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -227,7 +227,7 @@ queue_process_setup <- function(test_package, test_dir, load_helpers, load_packa
     test_package = test_package,
     load_helpers = load_helpers,
     env = env,
-    exit_frame = .GlobalEnv
+    frame = .GlobalEnv
   )
 
   # Save test environment in global env where it can easily be retrieved

--- a/R/test-files.R
+++ b/R/test-files.R
@@ -275,23 +275,28 @@ find_load_all_args <- function(path) {
   )
 }
 
-test_files_setup_state <- function(test_dir, test_package, load_helpers, env, .env = parent.frame()) {
-
+test_files_setup_state <- function(
+    test_dir,
+    test_package,
+    load_helpers,
+    env,
+    exit_frame = parent.frame()
+) {
   # Define testing environment
-  local_test_directory(test_dir, test_package, .env = .env)
+  local_test_directory(test_dir, test_package, .env = exit_frame)
   withr::local_options(
     topLevelEnvironment = env_parent(env),
-    .local_envir = .env
+    .local_envir = exit_frame
   )
 
   # Load helpers, setup, and teardown (on exit)
-  local_teardown_env(.env)
+  local_teardown_env(exit_frame)
   if (load_helpers) {
     source_test_helpers(".", env)
   }
   source_test_setup(".", env)
-  withr::defer(withr::deferred_run(teardown_env()), .env) # new school
-  withr::defer(source_test_teardown(".", env), .env)      # old school
+  withr::defer(withr::deferred_run(teardown_env()), exit_frame) # new school
+  withr::defer(source_test_teardown(".", env), exit_frame)      # old school
 }
 
 test_files_reporter <- function(reporter, .env = parent.frame()) {

--- a/R/test-files.R
+++ b/R/test-files.R
@@ -280,23 +280,23 @@ test_files_setup_state <- function(
     test_package,
     load_helpers,
     env,
-    exit_frame = parent.frame()
+    frame = parent.frame()
 ) {
   # Define testing environment
-  local_test_directory(test_dir, test_package, .env = exit_frame)
+  local_test_directory(test_dir, test_package, .env = frame)
   withr::local_options(
     topLevelEnvironment = env_parent(env),
-    .local_envir = exit_frame
+    .local_envir = frame
   )
 
   # Load helpers, setup, and teardown (on exit)
-  local_teardown_env(exit_frame)
+  local_teardown_env(frame)
   if (load_helpers) {
     source_test_helpers(".", env)
   }
   source_test_setup(".", env)
-  withr::defer(withr::deferred_run(teardown_env()), exit_frame) # new school
-  withr::defer(source_test_teardown(".", env), exit_frame)      # old school
+  withr::defer(withr::deferred_run(teardown_env()), frame) # new school
+  withr::defer(source_test_teardown(".", env), frame)      # old school
 }
 
 test_files_reporter <- function(reporter, .env = parent.frame()) {


### PR DESCRIPTION
I got confused while reading `test_files_setup_state()` because it takes the test environment as `env` and the exit frame as `.env`. This PR clarifies the naming.