### PR TITLE
improve `test_path()` manual

### DIFF
--- a/R/test-path.R
+++ b/R/test-path.R
@@ -1,7 +1,10 @@
 #' Locate file in testing directory.
 #'
 #' This function is designed to work both interactively and during tests,
-#' locating files in the `tests/testthat` directory
+#' locating files in the `tests/testthat` directory.
+#'
+#' @section Warning:
+#' `test_path()` will work in test files, but not in helper files.
 #'
 #' @param ... Character vectors giving path component.
 #' @return A character vector giving the path.

--- a/man/test_path.Rd
+++ b/man/test_path.Rd
@@ -14,5 +14,10 @@ A character vector giving the path.
 }
 \description{
 This function is designed to work both interactively and during tests,
-locating files in the \code{tests/testthat} directory
+locating files in the \code{tests/testthat} directory.
 }
+\section{Warning}{
+
+\code{test_path()} will work in test files, but not in helper files.
+}
+


### PR DESCRIPTION
Clarifies that `test_path()` will not work in helper files.

Fixes https://github.com/r-lib/testthat/issues/1562