### PR TITLE
test-fixtures.Rmd exists/exits typo

### DIFF
--- a/vignettes/test-fixtures.Rmd
+++ b/vignettes/test-fixtures.Rmd
@@ -163,7 +163,7 @@ neater <- function(x, sig_digits) {
 neater(pi)
 ```
 
-This code doesn't work because the cleanup happens too soon, when `local_digits()` exists, not when `neat()` finishes.
+This code doesn't work because the cleanup happens too soon, when `local_digits()` exits, not when `neat()` finishes.
 
 Fortunately, `withr::defer()` allows us to solve this problem by providing an `envir` argument that allows you to control when cleanup occurs. The exact details of how this works are rather complicated, but fortunately there's a common pattern you can use without understanding all the details. Your helper function should always have an `env` argument that defaults to `parent.frame()`, which you pass to the second argument of `defer()`:
 


### PR DESCRIPTION
This accidentally implies the opposite of what it means.