### PR TITLE
Set minimum pkgload version for is_loading()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     lifecycle,
     magrittr,
     methods,
-    pkgload,
+    pkgload (>= 1.3.0),
     praise,
     processx,
     ps (>= 1.3.4),


### PR DESCRIPTION
Required here:

https://github.com/r-lib/testthat/blob/86b85130beec27d8a73b75049fea585f9ff34dc0/R/test-path.R#L21

{pkgload} ref:

https://github.com/r-lib/pkgload/blob/60a0eae8d464acedc3f6bb42c8cd8cdda26ef057/NEWS.md?plain=1#L74-L75