### PR TITLE
CRAN never runs code interactively

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # testthat (development version)
 
+* `skip_on_cran()` no longer skips (errors) when run interactively.
+
 * When using parallel tests, links to failed tests etc now work (#1787).
 
 * testthat no longer truncates tracebacks and uses rlang's default tree

--- a/R/skip.R
+++ b/R/skip.R
@@ -247,7 +247,7 @@ on_bioc <- function() {
   env_var_is_true("IS_BIOC_BUILD_MACHINE")
 }
 on_cran <- function() {
-  !env_var_is_true("NOT_CRAN")
+  !is_interactive() && !env_var_is_true("NOT_CRAN")
 }
 
 env_var_is_true <- function(x) {

--- a/tests/testthat/test-skip.R
+++ b/tests/testthat/test-skip.R
@@ -61,6 +61,10 @@ test_that("skip_on_cran() works as expected", {
 
   withr::local_envvar(NOT_CRAN = "false")
   expect_snapshot_skip(skip_on_cran())
+
+  withr::local_options(rlang_interactive = TRUE)
+  expect_no_skip(skip_on_cran())
+
 })
 
 


### PR DESCRIPTION
This makes it easier to run through code line-by-line, particularly when `skip_on_cran()` is nested inside another skip helper.


@DavisVaughan I think we've talked about this before, but I've decided to bite the bullet because it makes line-by-line testing in renv easier.