### PR TITLE
Actually test skip_on_cran()

### DIFF
--- a/R/expect-self-test.R
+++ b/R/expect-self-test.R
@@ -47,8 +47,8 @@ expect_failure <- function(expr, message = NULL, ...) {
   invisible(NULL)
 }
 
-expect_snapshot_skip <- function(x) {
-  expect_snapshot_error(x, class = "skip")
+expect_snapshot_skip <- function(x, cran = FALSE) {
+  expect_snapshot_error(x, class = "skip", cran = cran)
 }
 expect_no_skip <- function(code) {
   expect_no_condition(code, class = "skip")

--- a/tests/testthat/test-skip.R
+++ b/tests/testthat/test-skip.R
@@ -56,17 +56,18 @@ test_that("skip_if_not_installed() works as expected", {
 })
 
 test_that("skip_on_cran() works as expected", {
+  skip_on_cran()
+
   withr::local_envvar(NOT_CRAN = "true")
   expect_no_skip(skip_on_cran())
 
   withr::local_envvar(NOT_CRAN = "false")
-  expect_snapshot_skip(skip_on_cran())
+  expect_snapshot_skip(skip_on_cran(), cran = TRUE)
 
   withr::local_options(rlang_interactive = TRUE)
   expect_no_skip(skip_on_cran())
 
 })
-
 
 test_that("skip_on_ci() works as expected", {
   withr::local_envvar(CI = "false")


### PR DESCRIPTION
When simulating being on CRAN, need to tell the snapshot test to actually run.