### PR TITLE
Ensure snapshot hint links work in parallel tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # testthat (development version)
 
+* Links generate for snapshot hints now work when using parallel tests (#1802).
+
 * Experimental `is_snapshotting()` to determine if code is running inside a 
   snapshot test (#1796).
 

--- a/R/parallel-taskq.R
+++ b/R/parallel-taskq.R
@@ -111,7 +111,10 @@ task_q <- R6::R6Class(
         fun = nl,
         args = nl,
         worker = nl)
-      rsopts <- callr::r_session_options(...)
+      rsopts <- callr::r_session_options(
+        ...,
+        cli.hyperlink = cli::ansi_has_hyperlink_support()
+      )
       for (i in seq_len(concurrency)) {
         rs <- callr::r_session$new(rsopts, wait = FALSE)
         private$tasks$worker[[i]] <- rs

--- a/R/parallel-taskq.R
+++ b/R/parallel-taskq.R
@@ -111,10 +111,7 @@ task_q <- R6::R6Class(
         fun = nl,
         args = nl,
         worker = nl)
-      rsopts <- callr::r_session_options(
-        ...,
-        cli.hyperlink = cli::ansi_has_hyperlink_support()
-      )
+      rsopts <- callr::r_session_options(...)
       for (i in seq_len(concurrency)) {
         rs <- callr::r_session$new(rsopts, wait = FALSE)
         private$tasks$worker[[i]] <- rs

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -224,6 +224,8 @@ queue_setup <- function(test_paths,
 
   test_package <- test_package %||% Sys.getenv("TESTTHAT_PKG")
 
+  hyperlinks <- cli::ansi_has_hyperlink_support()
+
   # First we load the package "manually", in case it is testthat itself
   load_hook <- expr({
     switch(!!load_package,
@@ -231,8 +233,10 @@ queue_setup <- function(test_paths,
       source = pkgload::load_all(!!test_dir, helpers = FALSE, quiet = TRUE)
     )
 
+    # Ensure snapshot can generate hyperlinks for snapshot_accept()
     options(
-      cli.hyperlink = !!cli::ansi_has_hyperlink_support()
+      cli.hyperlink = !!hyperlinks,
+      cli.hyperlink_run = !!hyperlinks
     )
 
     asNamespace("testthat")$queue_process_setup(

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -230,6 +230,11 @@ queue_setup <- function(test_paths,
       installed = library(!!test_package, character.only = TRUE),
       source = pkgload::load_all(!!test_dir, helpers = FALSE, quiet = TRUE)
     )
+
+    options(
+      cli.hyperlink = !!cli::ansi_has_hyperlink_support()
+    )
+
     asNamespace("testthat")$queue_process_setup(
       test_package = !!test_package,
       test_dir = !!test_dir,


### PR DESCRIPTION
Fixes #1802