### PR TITLE
treat browser() as error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # testthat (development version)
 
+* `testthat` now sets the `_R_CHECK_BROWSER_NONINTERACTIVE_` environment variable
+  when running tests. This should ensure that left-over `browser()` statements
+  will trigger an error if encountered while running tests. (#1825)
+
 # testthat 3.1.9
 
 * New `expect_contains()` and `expect_in()` that works similarly to 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 * `testthat` now sets the `_R_CHECK_BROWSER_NONINTERACTIVE_` environment variable
   when running tests. This should ensure that left-over `browser()` statements
-  will trigger an error if encountered while running tests. (#1825)
+  will trigger an error if encountered while running tests. This functionality
+  is only enabled with R (>= 4.3.0). (#1825)
 
 # testthat 3.1.9
 

--- a/R/local.R
+++ b/R/local.R
@@ -65,7 +65,7 @@
 #'   cat("\n")
 #' })
 local_test_context <- function(.env = parent.frame()) {
-  withr::local_envvar(TESTTHAT = "true", .local_envir = .env)
+  withr::local_envvar("_R_CHECK_BROWSER_NONINTERACTIVE_" = "true", TESTTHAT = "true", .local_envir = .env)
   if (edition_get() >= 3) {
     local_reproducible_output(.env = .env)
   }

--- a/tests/testthat/test-browser.R
+++ b/tests/testthat/test-browser.R
@@ -1,0 +1,5 @@
+
+test_that("browser() usages are errors in tests", {
+  if (!interactive())
+    expect_error(browser())
+})

--- a/tests/testthat/test-browser.R
+++ b/tests/testthat/test-browser.R
@@ -1,5 +1,6 @@
 
 test_that("browser() usages are errors in tests", {
+  skip_if(getRversion() < "4.3.0")
   if (!interactive())
     expect_error(browser())
 })


### PR DESCRIPTION
Closes https://github.com/r-lib/testthat/issues/1825.