### PR TITLE
Better approach for mocking base functions

### DIFF
--- a/R/mock2.R
+++ b/R/mock2.R
@@ -48,11 +48,21 @@
 #'
 #' ## Base functions
 #'
-#' Note that it's not possible to mock functions in the base namespace
-#' (i.e. functions that you can use without explicitly importing them)
-#' since currently we don't know of a way to to mock them without potentially
-#' affecting all running code. If you need to mock a base function, you'll
-#' need to create a wrapper, as described below.
+#' To mock a function in the base package, you need to make sure that you
+#' have a binding for this function in your package. It's easiest to do this
+#' by binding the value to `NULL`. For example, if you wanted to mock
+#' `interactive()` in your package, you'd need to include this code somewhere
+#' in your package:
+#'
+#' ```R
+#' interactive <- NULL
+#' ```
+#'
+#' Why is this necessary? `with_mocked_bindings()` and `local_mocked_bindings()`
+#' work by temporarily modifying the bindings within your package's namespace.
+#' When these tests are running inside of `R CMD check` the namespace is locked
+#' which means it's not possible to create new bindings so you need to make sure
+#' that the binding exists already.
 #'
 #' ## Namespaced calls
 #'

--- a/R/mock2.R
+++ b/R/mock2.R
@@ -242,6 +242,10 @@ test_mock_method.integer <- function(x) {
   "y"
 }
 
+test_mock_base <- function() {
+  interactive()
+}
+interactive <- NULL
 
 show_bindings <- function(name, env = caller_env()) {
   envs <- env_parents(env)

--- a/man/local_mocked_bindings.Rd
+++ b/man/local_mocked_bindings.Rd
@@ -68,11 +68,20 @@ you mock it the same way:
 
 \subsection{Base functions}{
 
-Note that it's not possible to mock functions in the base namespace
-(i.e. functions that you can use without explicitly importing them)
-since currently we don't know of a way to to mock them without potentially
-affecting all running code. If you need to mock a base function, you'll
-need to create a wrapper, as described below.
+To mock a function in the base package, you need to make sure that you
+have a binding for this function in your package. It's easiest to do this
+by binding the value to \code{NULL}. For example, if you wanted to mock
+\code{interactive()} in your package, you'd need to include this code somewhere
+in your package:
+
+\if{html}{\out{<div class="sourceCode R">}}\preformatted{interactive <- NULL
+}\if{html}{\out{</div>}}
+
+Why is this necessary? \code{with_mocked_bindings()} and \code{local_mocked_bindings()}
+work by temporarily modifying the bindings within your package's namespace.
+When these tests are running inside of \verb{R CMD check} the namespace is locked
+which means it's not possible to create new bindings so you need to make sure
+that the binding exists already.
 }
 
 \subsection{Namespaced calls}{

--- a/tests/testthat/test-mock2.R
+++ b/tests/testthat/test-mock2.R
@@ -77,3 +77,7 @@ test_that("can't mock bindings that don't exist", {
   expect_snapshot(local_mocked_bindings(f = function() "x"), error = TRUE)
 })
 
+test_that("can mock base functions with in-package bindings", {
+  local_mocked_bindings(interactive = function() TRUE)
+  expect_equal(test_mock_base(), TRUE)
+})


### PR DESCRIPTION
It just occurred to me that you only need _a_ binding, not a specific implementation. So this makes mocking base functions a little bit easier.