### PR TITLE
Allow mocking of R6 classes

### DIFF
--- a/R/mock2.R
+++ b/R/mock2.R
@@ -206,7 +206,7 @@ check_bindings <- function(x, error_call = caller_env()) {
     )
   }
 
-  is_fun <- map_lgl(x, is.function)
+  is_fun <- map_lgl(x, is.function) | map_lgl(x, R6::is.R6Class)
   if (!any(is_fun)) {
     cli::cli_abort(
       "All elements of {.arg ...} must be functions.",
@@ -246,6 +246,19 @@ test_mock_base <- function() {
   interactive()
 }
 interactive <- NULL
+
+test_mock_r6class <- R6::R6Class(
+  "test_mock_class",
+  public = list(
+    initalize = function(...) {},
+    val = "y"
+  )
+)
+
+test_mock_r6_internal <- function() {
+  m <- test_mock_r6class$new()
+  m$val
+}
 
 show_bindings <- function(name, env = caller_env()) {
   envs <- env_parents(env)

--- a/tests/testthat/test-mock2.R
+++ b/tests/testthat/test-mock2.R
@@ -81,3 +81,19 @@ test_that("can mock base functions with in-package bindings", {
   local_mocked_bindings(interactive = function() TRUE)
   expect_equal(test_mock_base(), TRUE)
 })
+
+test_that("can mock r6 classes", {
+  local({
+    local_mocked_bindings(
+      test_mock_r6class = R6::R6Class(
+        "test_mock_class",
+        public = list(
+          initalize = function(...) {},
+          val = "x"
+        )
+      )
+    )
+    expect_equal(test_mock_r6_internal(), "x")
+  })
+  expect_equal(test_mock_r6_internal(), "y")
+})


### PR DESCRIPTION
Allow for mocking R6 classes. 

I'm not familiar with the internal details of R6, and whether this simple change captures all the caveats. So this is just a method that worked for me. 

EDIT: did more extensive testing - this should work