### PR TITLE
Make it possible to suppress praise in StopReporter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # testthat (development version)
 
+* `StopReporter()` gains the ability to suppress praise when a test passes.
+
 * `expect_snapshot_file()` now generates clickable links to review changes 
   (#1821).
 

--- a/R/reporter-stop.R
+++ b/R/reporter-stop.R
@@ -16,10 +16,12 @@ StopReporter <- R6::R6Class("StopReporter",
     failures = NULL,
     n_fail = 0L,
     stop_reporter = TRUE,
+    praise = TRUE,
 
-    initialize = function(stop_reporter = TRUE) {
+    initialize = function(stop_reporter = TRUE, praise = TRUE) {
       super$initialize()
       self$failures <- Stack$new()
+      self$praise <- praise
       self$stop_reporter <- stop_reporter
     },
 
@@ -43,13 +45,15 @@ StopReporter <- R6::R6Class("StopReporter",
       self$local_user_output()
 
       failures <- self$failures$as_list()
-      if (length(failures) == 0) {
+      if (length(failures) == 0 && self$praise) {
         self$cat_line(colourise("Test passed", "success"), " ", praise_emoji())
         return()
       }
 
       messages <- vapply(failures, issue_summary, rule = TRUE, character(1))
-      self$cat_line(messages, "\n")
+      if (length(messages) > 0) {
+        self$cat_line(messages, "\n")
+      }
     },
     stop_if_needed = function() {
       if (self$stop_reporter && self$n_fail > 0) {

--- a/tests/testthat/_snaps/reporter-stop.md
+++ b/tests/testthat/_snaps/reporter-stop.md
@@ -44,3 +44,7 @@
     Reason: empty test
     
 
+# can suppress praise
+
+    
+

--- a/tests/testthat/test-reporter-stop.R
+++ b/tests/testthat/test-reporter-stop.R
@@ -2,6 +2,13 @@ test_that("produces useful output", {
   expect_snapshot_reporter(StopReporter$new())
 })
 
+test_that("can suppress praise", {
+  expect_snapshot_reporter(
+    StopReporter$new(praise = FALSE),
+    test_path("reporters/successes.R")
+  )
+})
+
 test_that("stop if needed errors when needed",{
   r <- StopReporter$new()
   expect_error(r$stop_if_needed(), NA)


### PR DESCRIPTION
As needed for devtools::test_coverage_active_file()