### PR TITLE
Remove ellipsis dependency in favour of rlang

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,6 @@ Imports:
     cli (>= 3.6.1),
     desc (>= 1.4.2),
     digest (>= 0.6.33),
-    ellipsis (>= 0.3.2),
     evaluate (>= 0.21),
     jsonlite (>= 1.8.7),
     lifecycle (>= 1.0.3),

--- a/R/deprec-condition.R
+++ b/R/deprec-condition.R
@@ -129,7 +129,7 @@ get_messages <- function(x) {
 #' has been deprecated.
 #'
 #' @param x An error object.
-#' @inheritParams ellipsis::dots_empty
+#' @inheritParams rlang::args_dots_empty
 #'
 #' @details
 #' A few classes are hard-coded as uninformative:

--- a/R/expect-condition.R
+++ b/R/expect-condition.R
@@ -255,7 +255,7 @@ expect_condition_matching <- function(base_class,
                                       info = NULL,
                                       label = NULL,
                                       trace_env = caller_env()) {
-  ellipsis::check_dots_used(action = warn)
+  check_dots_used(error = warning)
 
   matcher <- cnd_matcher(
     base_class,


### PR DESCRIPTION
was further tweaked in https://github.com/r-lib/testthat/commit/932989cc0f1836ef1498c8fe755164f61d03bc35 and transformed to 

```r
  check_dots_used(error = function(cnd) {
    warn(conditionMessage(cnd), call = error_call)
  })
```

Usage of `check_dots_used()` was removed in https://github.com/r-lib/testthat/pull/2014
which led me to open https://github.com/r-lib/rlang/issues/1675