### PR TITLE
Drop obsolete references to R3.5

### DIFF
--- a/tests/testthat/test-expect-known.R
+++ b/tests/testthat/test-expect-known.R
@@ -105,7 +105,6 @@ test_that("equal_to_ref does not overwrite existing", {
 })
 
 test_that("serializes to version 2 by default", {
-  skip_if(getRversion() < "3.5")
   tmp_rds <- tempfile(fileext = ".rds")
   on.exit(unlink(tmp_rds))
 
@@ -118,7 +117,6 @@ test_that("serializes to version 2 by default", {
 })
 
 test_that("version 3 is possible", {
-  skip_if(getRversion() < "3.5")
   tmp_rds <- tempfile(fileext = ".rds")
   on.exit(unlink(tmp_rds))
 

--- a/vignettes/test-fixtures.Rmd
+++ b/vignettes/test-fixtures.Rmd
@@ -10,7 +10,7 @@ vignette: >
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>",
+  comment = "#>"
 )
 ```
 

--- a/vignettes/test-fixtures.Rmd
+++ b/vignettes/test-fixtures.Rmd
@@ -11,8 +11,6 @@ vignette: >
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
-  # Since after is not available prior to 3.5
-  eval = getRversion() >= "3.5"
 )
 ```
 


### PR DESCRIPTION
New release depends on R>=3.6.0, so these skips & conditional eval are redundant

This change covers all the relevant references to 3.5 in the code base:

https://github.com/search?q=repo%3Ar-lib%2Ftestthat+%2F3%5B.%5D5%2F&type=code