### PR TITLE
Remove obsolete backports

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -9,29 +9,10 @@ escape_regex <- function(x) {
   gsub(paste0("([\\", paste0(collapse = "\\", chars), "])"), "\\\\\\1", x, perl = TRUE)
 }
 
-# For R 3.1
-dir.exists <- function(paths) {
-  file.exists(paths) & file.info(paths)$isdir
-}
-
 maybe_restart <- function(restart) {
   if (!is.null(findRestart(restart))) {
     invokeRestart(restart)
   }
-}
-
-# Backport for R 3.2
-strrep <- function(x, times) {
-  x = as.character(x)
-  if (length(x) == 0L)
-    return(x)
-  unlist(.mapply(function(x, times) {
-    if (is.na(x) || is.na(times))
-      return(NA_character_)
-    if (times <= 0L)
-      return("")
-    paste0(replicate(times, x), collapse = "")
-  }, list(x = x, times = times), MoreArgs = list()), use.names = FALSE)
 }
 
 # Backport for R < 4.0


### PR DESCRIPTION
Don't rely on custom logic now that R>=3.6.0 is required

If these were included via {backports}' definitions, we could rely on {lintr} to flag when such definitions become obsolete (eventually):

https://github.com/r-lib/lintr/issues/2182