### PR TITLE
Add options scope to junitreporter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -57,7 +57,7 @@
 
 * `test_file()` gains a `desc` argument which allows you to run a single 
   test from a file (#1776).
-  
+
 # testthat 3.1.10
 
 * Fix for upcoming R-devel release.

--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,9 @@
 
 * `test_file()` gains a `desc` argument which allows you to run a single 
   test from a file (#1776).
+  
+* `JunitReporter()` now uses ensures numeric values are saved the xml file 
+  with `.` as decimal separator. (@maksymiuks, #1660)
 
 # testthat 3.1.10
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # testthat (development version)
 
+* `JunitReporter()` now uses ensures numeric values are saved the xml file 
+  with `.` as decimal separator. (@maksymiuks, #1660)
+
 # testthat 3.2.0
 
 ## Lifecycle changes
@@ -55,9 +58,6 @@
 * `test_file()` gains a `desc` argument which allows you to run a single 
   test from a file (#1776).
   
-* `JunitReporter()` now uses ensures numeric values are saved the xml file 
-  with `.` as decimal separator. (@maksymiuks, #1660)
-
 # testthat 3.1.10
 
 * Fix for upcoming R-devel release.

--- a/R/reporter-junit.R
+++ b/R/reporter-junit.R
@@ -85,22 +85,27 @@ JunitReporter <- R6::R6Class("JunitReporter",
     },
 
     end_context = function(context) {
+      # Make sure that any options posed by particular tests environments
+      # will not interfere with how values are saved to the file
+      withr::local_options(list(OutDec = "."))
       xml2::xml_attr(self$suite, "tests") <- as.character(self$tests)
       xml2::xml_attr(self$suite, "skipped") <- as.character(self$skipped)
       xml2::xml_attr(self$suite, "failures") <- as.character(self$failures)
       xml2::xml_attr(self$suite, "errors") <- as.character(self$errors)
       #jenkins junit plugin requires time has at most 3 digits
       xml2::xml_attr(self$suite, "time") <- as.character(round(self$suite_time, 3))
-
+      
       self$reset_suite()
+  
     },
 
     add_result = function(context, test, result) {
+      withr::local_options(list(OutDec = "."))
       self$tests <- self$tests + 1
-
+      
       time <- self$elapsed_time()
       self$suite_time <- self$suite_time + time
-
+      
       # XML node for test case
       name <- test %||% "(unnamed)"
       testcase <- xml2::xml_add_child(
@@ -109,12 +114,12 @@ JunitReporter <- R6::R6Class("JunitReporter",
         classname = classnameOK(context),
         name = classnameOK(name)
       )
-
+      
       first_line <- function(x) {
         loc <- expectation_location(x, " (", ")")
         paste0(strsplit(x$message, split = "\n")[[1]][1], loc)
       }
-
+      
       # add an extra XML child node if not a success
       if (expectation_error(result)) {
         # "type" in Java is the exception class

--- a/R/reporter-junit.R
+++ b/R/reporter-junit.R
@@ -85,8 +85,7 @@ JunitReporter <- R6::R6Class("JunitReporter",
     },
 
     end_context = function(context) {
-      # Make sure that any options posed by particular tests environments
-      # will not interfere with how values are saved to the file
+      # Always uses . as decimal place in output regardless of options set in test
       withr::local_options(list(OutDec = "."))
       xml2::xml_attr(self$suite, "tests") <- as.character(self$tests)
       xml2::xml_attr(self$suite, "skipped") <- as.character(self$skipped)
@@ -94,18 +93,17 @@ JunitReporter <- R6::R6Class("JunitReporter",
       xml2::xml_attr(self$suite, "errors") <- as.character(self$errors)
       #jenkins junit plugin requires time has at most 3 digits
       xml2::xml_attr(self$suite, "time") <- as.character(round(self$suite_time, 3))
-      
+
       self$reset_suite()
-  
     },
 
     add_result = function(context, test, result) {
       withr::local_options(list(OutDec = "."))
       self$tests <- self$tests + 1
-      
+
       time <- self$elapsed_time()
       self$suite_time <- self$suite_time + time
-      
+
       # XML node for test case
       name <- test %||% "(unnamed)"
       testcase <- xml2::xml_add_child(
@@ -114,12 +112,12 @@ JunitReporter <- R6::R6Class("JunitReporter",
         classname = classnameOK(context),
         name = classnameOK(name)
       )
-      
+
       first_line <- function(x) {
         loc <- expectation_location(x, " (", ")")
         paste0(strsplit(x$message, split = "\n")[[1]][1], loc)
       }
-      
+
       # add an extra XML child node if not a success
       if (expectation_error(result)) {
         # "type" in Java is the exception class


### PR DESCRIPTION
Resolves #1660 

According to @hadley's suggestions, I just enforced the decimal operator as an option scoped to the entire function. With that change, JUnit file should always be valid regardless of the decimal separator option used in the test.
