### PR TITLE
Make skip_if_offline() more robust by checking multiple hosts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # testthat (development version)
 
+* `skip_if_offline()` now uses `captive.apple.com` by default. This is the 
+  host that Apple devices use to check that they're online so should be 
+  a higher reliability host than `r-project.org` (@jdblischak, #1890).
+
 * `test_file(desc = )` will now find `describe()` tests as well as `testthat()`
   tests (#1903).
 

--- a/R/skip.R
+++ b/R/skip.R
@@ -122,14 +122,19 @@ package_version <- function(x) {
 
 #' @export
 #' @rdname skip
-skip_if_offline <- function(host = "r-project.org") {
+skip_if_offline <- function(host = c("r-project.org", "github.com", "captive.apple.com")) {
   skip_on_cran()
   check_installed("curl")
 
   skip_if_not(has_internet(host), "offline")
 }
 has_internet <- function(host) {
-  !is.null(curl::nslookup(host, error = FALSE))
+  for (h in host) {
+    if (!is.null(curl::nslookup(h, error = FALSE))) {
+      return(TRUE)
+    }
+  }
+  return(FALSE)
 }
 
 #' @export

--- a/R/skip.R
+++ b/R/skip.R
@@ -122,19 +122,14 @@ package_version <- function(x) {
 
 #' @export
 #' @rdname skip
-skip_if_offline <- function(host = c("r-project.org", "github.com", "captive.apple.com")) {
+skip_if_offline <- function(host = "captive.apple.com") {
   skip_on_cran()
   check_installed("curl")
 
   skip_if_not(has_internet(host), "offline")
 }
 has_internet <- function(host) {
-  for (h in host) {
-    if (!is.null(curl::nslookup(h, error = FALSE))) {
-      return(TRUE)
-    }
-  }
-  return(FALSE)
+  !is.null(curl::nslookup(host, error = FALSE))
 }
 
 #' @export

--- a/man/skip.Rd
+++ b/man/skip.Rd
@@ -22,7 +22,7 @@ skip_if(condition, message = NULL)
 
 skip_if_not_installed(pkg, minimum_version = NULL)
 
-skip_if_offline(host = c("r-project.org", "github.com", "captive.apple.com"))
+skip_if_offline(host = "captive.apple.com")
 
 skip_on_cran()
 

--- a/man/skip.Rd
+++ b/man/skip.Rd
@@ -22,7 +22,7 @@ skip_if(condition, message = NULL)
 
 skip_if_not_installed(pkg, minimum_version = NULL)
 
-skip_if_offline(host = "r-project.org")
+skip_if_offline(host = c("r-project.org", "github.com", "captive.apple.com"))
 
 skip_on_cran()
 


### PR DESCRIPTION
r-project.org has been down all morning, which is causing my package tests to be skipped. This PR updates `skip_if_offline()` to check multiple hosts, and returns `TRUE` on the first connection. It's backwards compatible because it still works when provided a single domain to `host`. And it will be just as fast once r-project.org is restored.

I added github.com since it's hard to get much done anyways when GitHub is down. And I added captive.apple.com because I learned from [sindresorhus/is-online](https://github.com/sindresorhus/is-online#how-it-works) that this is how iOS determines internet connectivity, so it should have a very reliable uptime.

If you are open to this update, I'll add an entry to `NEWS.md`