### PR TITLE
`test_file(desc =)` now also finds `describe()` tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # testthat (development version)
 
+* `test_file(desc = )` will now find `describe()` tests as well as `testthat()`
+  tests (#1903).
+
 * `JunitReporter()` now uses ensures numeric values are saved the xml file 
   with `.` as decimal separator. (@maksymiuks, #1660)
 

--- a/R/source.R
+++ b/R/source.R
@@ -71,7 +71,7 @@ filter_desc <- function(exprs, desc = NULL, error_call = caller_env()) {
   for (i in seq_along(exprs)) {
     expr <- exprs[[i]]
 
-    if (!is_call(expr, "test_that", n = 2)) {
+    if (!is_call(expr, c("test_that", "describe"), n = 2)) {
       if (!found) {
         include[[i]] <- TRUE
       }

--- a/R/test-files.R
+++ b/R/test-files.R
@@ -109,7 +109,7 @@ test_dir <- function(path,
 #' @param path Path to file.
 #' @param ... Additional parameters passed on to `test_dir()`
 #' @param desc Optionally, supply a string here to run only a single
-#'   test that has this `desc`ription.
+#'   test (`test_that()` or `describe()`) with this `desc`ription.
 #' @export
 #' @examples
 #' path <- testthat_example("success")

--- a/man/test_file.Rd
+++ b/man/test_file.Rd
@@ -22,7 +22,7 @@ as a string (e.g. "summary") or as an R6 object
 See \link{Reporter} for more details and a list of built-in reporters.}
 
 \item{desc}{Optionally, supply a string here to run only a single
-test that has this \code{desc}ription.}
+test (\code{test_that()} or \code{describe()}) with this \code{desc}ription.}
 
 \item{package}{If these tests belong to a package, the name of the package.}
 

--- a/tests/testthat/test-source.R
+++ b/tests/testthat/test-source.R
@@ -54,7 +54,7 @@ test_that("can find only matching test", {
     f(),
     test_that("foo", {}),
     g(),
-    test_that("bar", {}),
+    describe("bar", {}),
     h()
   )
   expect_equal(filter_desc(code, "foo"), code[c(1, 2)])


### PR DESCRIPTION
Fixes #1903