### PR TITLE
Don't evaluate `deferred_run()` example

### DIFF
--- a/vignettes/test-fixtures.Rmd
+++ b/vignettes/test-fixtures.Rmd
@@ -133,7 +133,7 @@ neat <- function(x, sig_digits) {
 
 Second, it works when called in the global environment. Since the global environment isn't perishable, like a test environment is, you have to call `deferred_run()` explicitly to execute the deferred events. You can also clear them, without running, with `deferred_clear()`.
 
-```{r}
+```{r, eval = FALSE}
 withr::defer(print("hi"))
 #> Setting deferred event(s) on global environment.
 #>   * Execute (and clear) with `deferred_run()`.


### PR DESCRIPTION
To avoid confusing output after https://github.com/r-lib/withr/issues/235 is fixed:

<img width="724" alt="Screenshot 2024-01-15 at 14 42 46" src="https://github.com/r-lib/testthat/assets/4465050/135e5354-615e-479f-ac3e-57957bb93ee9">
