### PR TITLE
Focus back on build pane after accepting snapshots

### DIFF
--- a/R/snapshot-manage.R
+++ b/R/snapshot-manage.R
@@ -41,7 +41,7 @@ snapshot_review <- function(files = NULL, path = "tests/testthat") {
   
   rs_avail <- rstudio_tickle()
   if (rs_avail) {
-    executeCommand("activateBuild")
+    rstudioapi::executeCommand("activateBuild")
   }
   invisible()
 }

--- a/R/snapshot-manage.R
+++ b/R/snapshot-manage.R
@@ -38,7 +38,11 @@ snapshot_review <- function(files = NULL, path = "tests/testthat") {
   }
 
   review_app(changed$name, changed$cur, changed$new)
-  rstudio_tickle()
+  
+  rs_avail <- rstudio_tickle()
+  if (rs_avai) {
+    executeCommand("activateBuild")
+  }
   invisible()
 }
 

--- a/R/snapshot-manage.R
+++ b/R/snapshot-manage.R
@@ -40,7 +40,7 @@ snapshot_review <- function(files = NULL, path = "tests/testthat") {
   review_app(changed$name, changed$cur, changed$new)
   
   rs_avail <- rstudio_tickle()
-  if (rs_avai) {
+  if (rs_avail) {
     executeCommand("activateBuild")
   }
   invisible()

--- a/R/utils.R
+++ b/R/utils.R
@@ -51,15 +51,16 @@ split_by_line <- function(x) {
 
 rstudio_tickle <- function() {
   if (!is_installed("rstudioapi")) {
-    return()
+    return(invisible(FALSE))
   }
 
   if (!rstudioapi::hasFun("executeCommand")) {
-    return()
+    return(invisible(FALSE))
   }
 
   rstudioapi::executeCommand("vcsRefresh")
   rstudioapi::executeCommand("refreshFiles")
+  invisible(TRUE)
 }
 
 first_upper <- function(x) {


### PR DESCRIPTION
Currently, it stays on Viewer (which becomes empty) after accepting snapshots.

This PR makes it, so that accepting snapshots with the review app focuses back to Build Pane automatically!