### PR TITLE
Fix check on R-devel

### DIFF
--- a/inst/include/testthat/testthat.h
+++ b/inst/include/testthat/testthat.h
@@ -172,7 +172,7 @@ inline std::ostream& cerr()
 extern "C" SEXP run_testthat_tests(SEXP use_xml_sxp) {
   bool use_xml = LOGICAL(use_xml_sxp)[0];
   bool success = testthat::run_tests(use_xml);
-  return ScalarLogical(success);
+  return Rf_ScalarLogical(success);
 }
 
 # endif // TESTTHAT_TEST_RUNNER
@@ -198,7 +198,7 @@ extern "C" SEXP run_testthat_tests(SEXP use_xml_sxp) {
 #  include <R.h>
 #  include <Rinternals.h>
 extern "C" SEXP run_testthat_tests() {
-  return ScalarLogical(true);
+  return Rf_ScalarLogical(true);
 }
 
 # endif // TESTTHAT_TEST_RUNNER


### PR DESCRIPTION
R-devel now uses `-DR_NO_REMAP` when running
`R CMD check --as-cran` [1].

This is the same as BDR's fix for testthat 3.2.1.1 [2].

[1] https://developer.r-project.org/blosxom.cgi/R-devel/NEWS/2024/04/14#n2024-04-14
[2] https://github.com/cran/testthat/commit/0c2c0a2c32a8442a4c3a6f0333e22b12678af1a