### PR TITLE
Better algorithm for determining file extension

### DIFF
--- a/R/snapshot-manage.R
+++ b/R/snapshot-manage.R
@@ -161,7 +161,7 @@ snapshot_meta <- function(files = NULL, path = "tests/testthat") {
     files <- files[!is_dir]
 
     dirs <- substr(dirs, 1, nchar(dirs) - 1)
-    files <- ifelse(tools::file_ext(files) == "", paste0(files, ".md"), files)
+    files <- ifelse(grepl("\\.md$", files), files, paste0(files, ".md"))
 
     out <- out[out$name %in% files | out$test %in% dirs, , drop = FALSE]
   }


### PR DESCRIPTION
Adjusted snapshot_meta helper function to adjust check for presence of file extension in `files` argument. Fixes issue where periods in file name are mistaken for file extension. Fixes #1579.

Implicitly assumes snapshot file extension will be `.md` or nothing, but based on review of the function I think this is valid.