### PR TITLE
Improve stack trace by creating message in separate variable

### DIFF
--- a/R/reporter-progress.R
+++ b/R/reporter-progress.R
@@ -214,10 +214,11 @@ ProgressReporter <- R6::R6Class("ProgressReporter",
           snapshotter$end_file()
         }
 
-        stop_reporter(c(
+        msg <- c(
           "Maximum number of failures exceeded; quitting at end of file.",
           i = "Increase this number with (e.g.) {.run testthat::set_max_fails(Inf)}"
-        ))
+        )
+        stop_reporter(msg)
       }
     },
 


### PR DESCRIPTION
Currently, we get this. This PR will simplify a little the message.

![image](https://github.com/user-attachments/assets/36b81b4e-eb8f-4e3c-a1f3-9f74fdc61f01)
