### PR TITLE
Better advice for mocked base functions.

### DIFF
--- a/R/mock2.R
+++ b/R/mock2.R
@@ -48,12 +48,12 @@
 #'
 #' To mock a function in the base package, you need to make sure that you
 #' have a binding for this function in your package. It's easiest to do this
-#' by binding the value to `NULL`. For example, if you wanted to mock
+#' by binding the name to the function. For example, if you wanted to mock
 #' `interactive()` in your package, you'd need to include this code somewhere
 #' in your package:
 #'
 #' ```R
-#' interactive <- NULL
+#' interactive <- interactive
 #' ```
 #'
 #' Why is this necessary? `with_mocked_bindings()` and `local_mocked_bindings()`

--- a/man/local_mocked_bindings.Rd
+++ b/man/local_mocked_bindings.Rd
@@ -70,11 +70,11 @@ you mock it the same way:
 
 To mock a function in the base package, you need to make sure that you
 have a binding for this function in your package. It's easiest to do this
-by binding the value to \code{NULL}. For example, if you wanted to mock
+by binding the name to the function. For example, if you wanted to mock
 \code{interactive()} in your package, you'd need to include this code somewhere
 in your package:
 
-\if{html}{\out{<div class="sourceCode R">}}\preformatted{interactive <- NULL
+\if{html}{\out{<div class="sourceCode R">}}\preformatted{interactive <- interactive
 }\if{html}{\out{</div>}}
 
 Why is this necessary? \code{with_mocked_bindings()} and \code{local_mocked_bindings()}


### PR DESCRIPTION
If the function is used as an argument somewhere, binding NULL to it causes that call to fail. Instead bind the actual function, and then mock that.

I think it might also be necessary to do the same for the other default packages, but I'm not certain. Will likely know better at the end of TDD!