### PR TITLE
Display expected condition class

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,25 +1,26 @@
 # testthat (development version)
 
+* `expect_condition()` and friends now include the `class` of the expected condition in the failure mesage, if used (#1987).
 * `LANGUAGE` is now set to `"C"` in reprocucible environments (i.e.
   `test_that()` blocks) to disable translations. This fixes warnings
   about being unable to set the language to `"en"` (#1925).
 
 # testthat 3.2.1
 
-* Fix incorrect format string detected by latest R-devel. Fix thanks to 
+* Fix incorrect format string detected by latest R-devel. Fix thanks to
   Tomas Kalibera.
 
-* `expect_snapshot()` handles unexpected errors like errors outside of 
+* `expect_snapshot()` handles unexpected errors like errors outside of
   snapshots, i.e. they terminate the entire test and get a traceback (#1906).
 
-* `JunitReporter()` now uses ensures numeric values are saved the xml file 
+* `JunitReporter()` now uses ensures numeric values are saved the xml file
   with `.` as decimal separator. (@maksymiuks, #1660)
 
-* `local_mocked_bindings()` can now mock any object, not just functions 
+* `local_mocked_bindings()` can now mock any object, not just functions
   (#1896).
 
-* `skip_if_offline()` now uses `captive.apple.com` by default. This is the 
-  hostname that Apple devices use to check that they're online so it should 
+* `skip_if_offline()` now uses `captive.apple.com` by default. This is the
+  hostname that Apple devices use to check that they're online so it should
   have a higher reliability than `r-project.org` (@jdblischak, #1890).
 
 * `test_file(desc = )` will now find `describe()` tests as well as `test_that()`
@@ -32,8 +33,8 @@
 * `is_informative_error()` and the `wrap` argument to `test_dir()` and friends
   are now defunct.
 
-* `expect_no_error()`, `expect_no_warning()`, `expect_no_message()`, 
-  `expect_no_condition()`, `local_mocked_bindings()`, and 
+* `expect_no_error()`, `expect_no_warning()`, `expect_no_message()`,
+  `expect_no_condition()`, `local_mocked_bindings()`, and
   `with_mocked_bindings()` are now stable, not experimental.
 
 ## New features
@@ -60,7 +61,7 @@
 * `expect_snapshot()` and friends no longer create a temporary file on every
   invocation.
 
-* `expect_snapshot_file()` now generates clickable links to review changes 
+* `expect_snapshot_file()` now generates clickable links to review changes
   (#1821).
 
 * `expect_snapshot_value()` has an improved error if the object can't be
@@ -74,10 +75,10 @@
 * `StopReporter` gains the ability to suppress praise when a test passes.
 
 * `ProgressReporter` now uses is a two characters wide skip column in order
-  to have a consistent width when 10 or more tests are skipped in a single file 
+  to have a consistent width when 10 or more tests are skipped in a single file
   (@mgirlich, #1844).
 
-* `test_file()` gains a `desc` argument which allows you to run a single 
+* `test_file()` gains a `desc` argument which allows you to run a single
   test from a file (#1776).
 
 # testthat 3.1.10
@@ -91,27 +92,27 @@
 
 # testthat 3.1.9
 
-* New `expect_contains()` and `expect_in()` that works similarly to 
-  `expect_true(all(expected %in% object))` or 
+* New `expect_contains()` and `expect_in()` that works similarly to
+  `expect_true(all(expected %in% object))` or
   `expect_true(all(object %in% expected))` but give more informative failure
   messages (#1346).
 
 * New `is_snapshot()` returns `TRUE` if code is running inside a snapshot test
-  (#1796) and `is_checking()` returns `TRUE` if test is running inside of 
+  (#1796) and `is_checking()` returns `TRUE` if test is running inside of
   `R CMD check` (#1795)
 
-* `ProgressReporter` only reports the run time of test files that take longer 
+* `ProgressReporter` only reports the run time of test files that take longer
   than 1s, rather than 0.1s. (#1806) and re-displays all failures at the end
-  of the results. Skips are now only shown at the end of reporter summaries, 
-  not as tests are run. This makes them less intrusive in interactive tests 
+  of the results. Skips are now only shown at the end of reporter summaries,
+  not as tests are run. This makes them less intrusive in interactive tests
   while still allowing you to verify that the correct tests are skipped (#1801).
-  When using parallel tests, links to failed tests (#1787) and links to 
+  When using parallel tests, links to failed tests (#1787) and links to
   accept/review snapshot (#1802) now work.
 
 * `set_state_inspector()` allows to to register a function that's called
   before and after every test, reporting on any differences. This
-  is very useful for detecting if any of your tests have made changes to 
-  global state (like options, env vars, or connections) (#1674). This 
+  is very useful for detecting if any of your tests have made changes to
+  global state (like options, env vars, or connections) (#1674). This
   function was inspired by renv's testing infrastructure.
 
 * `skip_on_cran()` no longer skips (errors) when run interactively.
@@ -126,7 +127,7 @@
 * `expect_snapshot()` differences no longer use quotes.
 
 * `expect_error()`, `expect_warning()`, and `expect_message()` now correctly
-  enforce that the condition is of the expected base class (e.g. error, 
+  enforce that the condition is of the expected base class (e.g. error,
   warning, message) even when the `class` argument is used (#1168).
 
 * `it()` now calls `local_test_context()` so that it behaves more
@@ -136,8 +137,8 @@
 * `skip_on_bioc()` now uses the documented environment variable
   (`IS_BIOC_BUILD_MACHINE`) (#1712).
 
-* `source_file()`, which is used by various parts of the helper and 
-  setup/teardown machinery, now reports the file name in the case of 
+* `source_file()`, which is used by various parts of the helper and
+  setup/teardown machinery, now reports the file name in the case of
   errors (#1704).
 
 * `test_path()` now works when called within helper files (#1562).
@@ -146,9 +147,9 @@
   that testthat uses (#1638).
 
 * `with_mocked_bindings()` and `local_mocked_bindings()` now also bind in the
-  imports namespace and can mock S3 methods. These changes make them good 
-  substitutes for the deprecated functions `with_mock()` and `local_mock()`, so 
-  those older functions now recommend switching to the newer equivalents 
+  imports namespace and can mock S3 methods. These changes make them good
+  substitutes for the deprecated functions `with_mock()` and `local_mock()`, so
+  those older functions now recommend switching to the newer equivalents
   instead of using the mockr or mockery packages.
 
 # testthat 3.1.7
@@ -157,7 +158,7 @@
 
 * `expect_snapshot()` no longer elides new lines when run interactively (#1726).
 
-* Experimental new `with_mocked_bindings()` and `local_mocked_bindings()` 
+* Experimental new `with_mocked_bindings()` and `local_mocked_bindings()`
   (#1739).
 
 # testthat 3.1.6
@@ -167,12 +168,12 @@
 # testthat 3.1.5
 
 * Deprecation warnings are no longer captured by `expect_warning(code, NA)`,
-  `expect_no_warning(code)`, or `expect_silent(code)`. This ensures that they 
-  bubble up to the top level so that you can address them (#1680). If you want 
+  `expect_no_warning(code)`, or `expect_silent(code)`. This ensures that they
+  bubble up to the top level so that you can address them (#1680). If you want
   to assert that code does not throw a deprecation warning, use
   `expect_no_condition(code(), class = "lifecycle_warning_deprecation")`.
 
-* New experimental `expect_no_error()`, `expect_no_warning()`, 
+* New experimental `expect_no_error()`, `expect_no_warning()`,
   `expect_no_message()`, and `expect_no_condition()` for asserting
   the code runs without an error, warning, message, or condition (#1679).
 
@@ -185,7 +186,7 @@
   (@kevinushey, #1687)
 
 * Improve way `capture_output()` handles encoding thanks to suggestion from
-  Kurt Hornik (#1693). This means that snapshots using UTF-8 encoded text on 
+  Kurt Hornik (#1693). This means that snapshots using UTF-8 encoded text on
   windows work once again.
 
 * `local_reproducible_output()` will no longer attempt to set the local language
@@ -239,7 +240,7 @@
     context of an error as part of messages, see the release notes of
     rlang 1.0.0 for more about this.
 
-* Test results show hyperlinks to failed expectation when supported (#1544). 
+* Test results show hyperlinks to failed expectation when supported (#1544).
 
 
 # testthat 3.1.2
@@ -251,28 +252,28 @@
   of errors and messages (#1509).
 
 * If `expect_snapshot()` generates a snapshot with different value but
-  still compares as equal (e.g. because you've set a numeric tolerance), the 
+  still compares as equal (e.g. because you've set a numeric tolerance), the
   saved values no longer update if another snapshot in the same file changes.
 
-* `expect_snapshot()` now only adds a `.new` file for the variants that 
+* `expect_snapshot()` now only adds a `.new` file for the variants that
   actually changed, not all variants, while `expect_snapshot_file()` with
   variant with no longer immediately deletes `.new` files (#1468).
 
-* `expect_snapshot_file()` gains a `transform` argument to match 
-  `expect_snapshot()` (#1474). `compare` now defaults to `NULL`, automatically 
+* `expect_snapshot_file()` gains a `transform` argument to match
+  `expect_snapshot()` (#1474). `compare` now defaults to `NULL`, automatically
   guessing the comparison type based on the extension.
 
-* `expect_snapshot_file()` now errors if the file being snapshot does not exist; 
-  `SnapshotReporter` also now treats the file directory as an absolute path 
+* `expect_snapshot_file()` now errors if the file being snapshot does not exist;
+  `SnapshotReporter` also now treats the file directory as an absolute path
   (#1476, @malcolmbarrett)
 
 * New `expect_snapshot_warning()` to match `expect_snapshot_error()` (#1532).
 
 * `JUnitReporter` now includes skip messages/reasons (@rfineman, #1507)
 
-* `local_reproducible_output()` gains a `lang` argument so that you can 
+* `local_reproducible_output()` gains a `lang` argument so that you can
   optionally override the language used to translate error messages (#1483).
-  It also sets the global option `cli.num_colors` in addition to 
+  It also sets the global option `cli.num_colors` in addition to
   `crayon.enabled`.
 
 * `test_that()` no longer inappropriately skips when calling `expect_equal()`
@@ -282,13 +283,13 @@
 
 * `snapshot_accept()` and `snapshot_review()` now work with exactly the same
   file specification which can be a snapshot name, a file name, or a directory
-  (#1546). They both work better with variants (#1508). Snapshot cleanup also 
+  (#1546). They both work better with variants (#1508). Snapshot cleanup also
   removes all empty directories (#1457).
 
-* When a snapshot changes the hint also mentions that you can use 
-  `snapshot_review()` (#1500, @DanChaltiel) and the message tells you what 
+* When a snapshot changes the hint also mentions that you can use
+  `snapshot_review()` (#1500, @DanChaltiel) and the message tells you what
   variant is active (#1540).
-* JUnit reporter now includes skip messages/reasons (@rfineman, #1507). 
+* JUnit reporter now includes skip messages/reasons (@rfineman, #1507).
 
 
 # testthat 3.1.1
@@ -337,32 +338,32 @@
 
 * `expect_snapshot()` is no longer experimental.
 
-* `expect_snapshot()` and friends gets an experimental new `variant` argument 
-  which causes the snapshot to be saved in `_snaps/{variant}/{test}.md` instead 
+* `expect_snapshot()` and friends gets an experimental new `variant` argument
+  which causes the snapshot to be saved in `_snaps/{variant}/{test}.md` instead
   of `_snaps/{test}.md`. This allows you to generate (and compare) unique
   snapshots for different scenarios like operating system or R version (#1143).
 
 * `expect_snapshot()` gains a `transform` argument, which should be a function that
   takes a character vector of lines and returns a modified character vector
-  of lines. This makes it easy to remove sensitive (e.g. API keys) or 
-  stochastic (e.g. random temporary directory names) from snapshot output 
+  of lines. This makes it easy to remove sensitive (e.g. API keys) or
+  stochastic (e.g. random temporary directory names) from snapshot output
   (#1345).
 
 * `expect_snapshot_file()` now replaces previous `.new` snapshot if code
   fails again with a different value.
 
-* `expect_snapshot_value()` now has an explicit `tolerance` argument which 
-  uses the testthat default, thus making it more like `expect_equal()` rather 
-  than `expect_identical()`. Set it to `NULL` if you want precise comparisons 
-  (#1309). `expect_snapshot_value(style = "deparse")` now works with negative 
+* `expect_snapshot_value()` now has an explicit `tolerance` argument which
+  uses the testthat default, thus making it more like `expect_equal()` rather
+  than `expect_identical()`. Set it to `NULL` if you want precise comparisons
+  (#1309). `expect_snapshot_value(style = "deparse")` now works with negative
   values (#1342).
 
 * If a test containing multiple snapshots fails (or skips) in between snapshots,
   the later snapshots are now silently restored. (Previously this warned and
   reset all snapshots, not just later snapshots).
-  
-* If you have multiple tests with the same name that use snapshots (not a good 
-  idea), you will no longer get a warning. Instead the snapshots will be 
+
+* If you have multiple tests with the same name that use snapshots (not a good
+  idea), you will no longer get a warning. Instead the snapshots will be
   aggregated across the tests.
 
 ## Breaking changes
@@ -371,24 +372,24 @@
   condition instead of the return value (#1371). Previously, they
   would only return the condition if the return value was `NULL`,
   leading to inconsistent behaviour.
-  
+
   This is a breaking change to the 3rd edition. Where you
   could previously do:
-  
+
   ```
   expect_equal(expect_warning(f(), "warning"), "value")
   ```
-  
+
   You must now use condition expectations on the outside:
-  
+
   ```
   expect_warning(expect_equal(f(), "value"), "warning")
-  
+
   # Equivalently, save the value before inspection
   expect_warning(value <- f(), "warning")
   expect_equal(value, "value")
   ```
-  
+
   This breaking change makes testthat more consistent. It also makes
   it possible to inspect both the value and the warning, which would
   otherwise require additional tools.
@@ -403,22 +404,22 @@
 * `expr_label()`, which is used to concisely describe expressions used in
   expectations, now does a better job of summarising infix function (#1442).
 
-* `local_reproducible_output()` now sets the `max.print` option to 99999 
+* `local_reproducible_output()` now sets the `max.print` option to 99999
   (the default), so your tests are unaffected by any changes you might've
   made in your `.Rprofile` (1367).
 
-* `ProgressReporter` (the default only) now stops at the end of a file; this 
-  ensures that you see the results of all related tests, and ensures that 
-  snapshots are handled consistently (#1402). 
-  
-* `ProgressReporter` now uses an env var to adjust the maximum number of 
+* `ProgressReporter` (the default only) now stops at the end of a file; this
+  ensures that you see the results of all related tests, and ensures that
+  snapshots are handled consistently (#1402).
+
+* `ProgressReporter` now uses an env var to adjust the maximum number of
   failures. This makes it easier to adjust when the tests are run in a
   subprocess, as is common when using RStudio (#1450).
 
 * `skip_on_os()` gains an `arch` argument so you can also choose to skip
-  selected architectures (#1421). 
+  selected architectures (#1421).
 
-* `test_that()` now correctly errors when an expectation fails when run 
+* `test_that()` now correctly errors when an expectation fails when run
   interactively (#1430).
 
 * `test_that()` now automatically and correctly generate an "empty test"
@@ -428,7 +429,7 @@
 * `testthat_tolerance()` no longer has an unused argument.
 
 # testthat 3.0.4
-  
+
 * The vendored Catch code used for `use_catch()` now uses a constant
   value for the stack size rather than relying on SIGSTKSZ. This
   fixes compatibility for recent glibc versions where SIGSTKSZ is no
@@ -443,7 +444,7 @@
 * `expect_snapshot_file()` gains a `compare` argument (#1378,
   @nbenn). This is a customisation point for how to compare old and
   new snapshot files.
-  
+
   The functions `compare_file_binary()` and `compare_file_text()` are
   now exported from testthat to be supplied as `compare`
   argument. These implement the same behaviour as the old `binary`
@@ -461,17 +462,17 @@
 * New expectation: `expect_no_match()`. It complements `expect_match()` by
   checking if a string **doesn't match** a regular expression
   (@michaelquinn32, #1381).
-  
+
  * Support setting the testthat edition via an environment variable
   (`TESTTHAT_EDITION`) as well (@michaelquinn32, #1386).
- 
+
 # testthat 3.0.2
 
 * Failing expectations now include a backtrace when they're not called directly
-  from within `test_that()` but are instead wrapped in some helper function 
+  from within `test_that()` but are instead wrapped in some helper function
   (#1307).
-  
-* `CheckReporter` now only records warnings when not on CRAN. Otherwise 
+
+* `CheckReporter` now only records warnings when not on CRAN. Otherwise
   failed CRAN revdep checks tend to be cluttered up with warnings (#1300).
   It automatically cleans up `testthat-problems.rds` left over from previous
   runs if the latest run is successful (#1314).
@@ -495,12 +496,12 @@
 * `CheckReporter` results have been tweaked based on experiences from running
   R CMD check on many packages. Hopefully it should now be easier to see
   the biggest problems (i.e. failures and errors) while still having
-  skips and warnings available to check if needed (#1274). And now the full 
+  skips and warnings available to check if needed (#1274). And now the full
   test name is always shown, no matter how long (#1268).
 
 * Catch C++ tests are no longer reported multiple times (#1237) and
   are automatically skipped on Solaris since Catch is not supported (#1257).
-  `use_catch()` makes it more clear that your package needs to suggest 
+  `use_catch()` makes it more clear that your package needs to suggest
   xml2 (#1235).
 
 * `auto_test_package()` works once again (@mbojan, #1211, #1214).
@@ -511,7 +512,7 @@
 
 * `expect_snapshot_value(style = "deparse")` handles more common R data
   structures.
-  
+
 * `expect_snapshot_value()` now passes `...` on to `waldo::compare()` (#1222).
 
 * `expect_snapshot_file()` gives a hint as to next steps when a failure
@@ -529,10 +530,10 @@
 
 * `RstudioReporter` has been renamed to `RStudioReporter`.
 
-* `skip_if_not()` no longer appends "is not TRUE" to custom messages 
+* `skip_if_not()` no longer appends "is not TRUE" to custom messages
   (@dpprdan, #1247).
 
-* `test_that()` now warns (3e only) if code doesn't have braces, since 
+* `test_that()` now warns (3e only) if code doesn't have braces, since
   that makes it hard to track the source of an error (#1280, @krlmlr).
 
 # testthat 3.0.0
@@ -548,38 +549,38 @@ Learn more in `vignette("third-edition")`.
 
 * `context()` is deprecated.
 
-* `expect_identical()` and `expect_equal()` use `waldo::compare()` to 
-   compare actual and expected results. This mostly yields much more 
+* `expect_identical()` and `expect_equal()` use `waldo::compare()` to
+   compare actual and expected results. This mostly yields much more
    informative output when the actual and expected values are different,
    but while writing it uncovered some bugs in the existing comparison
    code.
-   
-* `expect_error()`, `expect_warning()`, `expect_message()`, and 
+
+* `expect_error()`, `expect_warning()`, `expect_message()`, and
   `expect_condition()` now all use the same underlying logic: they
   capture the first condition that matches `class`/`regexp` and
-  allow anything else to bubble up (#998/#1052). They also warn if 
+  allow anything else to bubble up (#998/#1052). They also warn if
   there are unexpected arguments that are never used.
 
 * The `all` argument to `expect_message()` and `expect_warning()` is now
-  deprecated. It was never a particularly good idea or well documented, 
+  deprecated. It was never a particularly good idea or well documented,
   and is now superseded by the new condition capturing behaviour.
 
-* `expect_equivalent()`, `expect_reference()`, `expect_is()` and 
+* `expect_equivalent()`, `expect_reference()`, `expect_is()` and
   `expect_that()` are deprecated.
 
-* Messages are no longer automatically silenced. Either use 
+* Messages are no longer automatically silenced. Either use
   `suppressMessages()` to hide unimportant messages, or
   `expect_message()` to catch important messages (#1095).
-  
+
 * `setup()` and `teardown()` are deprecated in favour of test fixtures.
   See `vignette("test-fixtures")` for more details.
-  
+
 * `expect_known_output()`, `expect_known_value()`, `expect_known_hash()`,
   and `expect_equal_to_reference()` are all deprecated in favour of
   `expect_snapshot_output()` and `expect_snapshot_value()`.
-  
-* `test_that()` now sets a number of options and env vars to make output as 
-  reproducible as possible (#1044). Many of these options were previously 
+
+* `test_that()` now sets a number of options and env vars to make output as
+  reproducible as possible (#1044). Many of these options were previously
   set in various places (in `devtools::test()`, `test_dir()`, `test_file()`,
   or `verify_output()`) but they have now been centralised. You can use in
   your own code, or when debugging tests interactively with
@@ -600,25 +601,25 @@ See `vignette("snapshotting")` for more details.
 ## Reporters
 
 * `CheckReporter` (used inside R CMD check) now prints out all problems
-  (i.e. errors, failures, warnings and skips; and not just the first 10), 
+  (i.e. errors, failures, warnings and skips; and not just the first 10),
   lists skips types, and records problems in machine readable format in
   `tests/testthat-problems.rds` (#1075).
-  
+
 * New `CompactProgressReporter` tweaks the output of `ProgressReporter` for
-  use with a single file, as in `devtools::test_file()`. You can pick a 
+  use with a single file, as in `devtools::test_file()`. You can pick a
   different default by setting `testthat.default_compact_reporter` to
   the name of a reporter.
 
 * `ProgressReporter` (the default reporter) now keeps the stack traces of
   an errors that happen before the before test, making problems substantially
-  easier to track down (#1004). It checks if you've exceeded the maximum number 
-  of failures (from option `testthat.progress.max_fails`) after each 
+  easier to track down (#1004). It checks if you've exceeded the maximum number
+  of failures (from option `testthat.progress.max_fails`) after each
   expectation, rather than at the end of each file (#967). It also gains
-  new random praise options that use emoji, and lists skipped tests by type 
+  new random praise options that use emoji, and lists skipped tests by type
   (#1028).
 
 * `StopReporter` adds random praise emoji when a single test passes (#1094).
-  It has more refined display of failures, now using the same style 
+  It has more refined display of failures, now using the same style
   as `CompactProgressReporter` and `ProgressReporter`.
 
 * `SummaryReporter` now records file start, not just context start. This
@@ -630,17 +631,17 @@ See `vignette("snapshotting")` for more details.
 
 * Warnings now include a backtrace, making it easier to figure
   out where they came from.
-  
-* Catch C++ tests now provide detailed results for each test. 
+
+* Catch C++ tests now provide detailed results for each test.
   To upgrade existing code, re-run `testthat::use_catch()` (#1008).
 
 * Many reporters (e.g. the check reporter) no longer raise an error when any tests fail. Use the `stop_on_failure` argument to `devtools::test()` and `testthat::test_dir()` if your code relies on this. Alternatively, use `reporter = c("check", "fail")` to e.g. create a failing check reporter.
 
 ## Fixtures
 
-* New `vignette("test-fixtures")` describes test fixtures; i.e. how to 
+* New `vignette("test-fixtures")` describes test fixtures; i.e. how to
   temporarily and cleanly change global state in order to test parts of
-  your code that otherwise would be hard to run (#1042). `setup()` and 
+  your code that otherwise would be hard to run (#1042). `setup()` and
   `teardown()` are superseded in favour of test fixtures.
 
 * New `teardown_env()` for use with `withr::defer()`. This allows you to
@@ -662,23 +663,23 @@ See `vignette("snapshotting")` for more details.
   warnings, and skips that occurred inside the test.
 
 * `test_that()` now errors if `desc` is not a string (#1161).
-  
+
 * `test_file()` now runs helper, setup, and teardown code, and has the
-  same arguments as `test_dir()` (#968). Long deprecated `encoding` argument 
+  same arguments as `test_dir()` (#968). Long deprecated `encoding` argument
   has been removed.
 
 * `test_dir()` now defaults `stop_on_failure` to `TRUE` for consistency with
   other `test_` functions. The `wrap` argument has been deprecated; it's not
   clear that it should ever have been exposed.
 
-* New `test_local()` tests a local source package directory. It's equivalent 
+* New `test_local()` tests a local source package directory. It's equivalent
   to `devtools::test()` but doesn't require devtools and all its dependencies
   to be installed (#1030).
 
 ## Minor improvements and bug fixes
 
 * testthat no longer supports tests stored in `inst/tests`. This has been
-  deprecated since testthat 0.11.0 (released in 2015). `test_package()` 
+  deprecated since testthat 0.11.0 (released in 2015). `test_package()`
   (previously used for running tests in R CMD check) will fail silently
   if no tests are found to avoid breaking old packages on CRAN (#1149).
 
@@ -699,9 +700,9 @@ See `vignette("snapshotting")` for more details.
 * `expect_true()`, `expect_false()`, and `expect_null()` now use waldo to
   produce more informative failures.
 
-* `verify_output()` no longer always fails if output contains a carriage 
-  return character ("\r") (#1048). It uses the `pdf()` device instead of 
-  `png()` so it works on systems without X11 (#1011). And it uses 
+* `verify_output()` no longer always fails if output contains a carriage
+  return character ("\r") (#1048). It uses the `pdf()` device instead of
+  `png()` so it works on systems without X11 (#1011). And it uses
   `waldo::compare()` to give more informative failures.
 
 # testthat 2.3.2
@@ -734,7 +735,7 @@ This release mostly focusses on an overhaul of how testthat works with condition
   makes it possible to generate messages at print-time rather than
   signal-time.
 
-* `expect_error()` gets a better warning message when you test for a custom 
+* `expect_error()` gets a better warning message when you test for a custom
   error class with `regexp`.
 
 * New `exp_signal()` function is a condition signaller that
@@ -745,8 +746,8 @@ This release mostly focusses on an overhaul of how testthat works with condition
   it possible to signal warnings or messages with a different
   condition signaller (#874).
 
-* `ListReporter` now tracks expectations and errors, even when they occur 
-  outside of tests. This ensures that `stop_on_failure` matches the results 
+* `ListReporter` now tracks expectations and errors, even when they occur
+  outside of tests. This ensures that `stop_on_failure` matches the results
   displayed by the reporter (#936).
 
 * You can silence warnings about untested error classes by
@@ -754,7 +755,7 @@ This release mostly focusses on an overhaul of how testthat works with condition
   should be lazily registered, e.g. with `vctrs::s3_register()`. This
   is useful for introducing an experimental error class without
   encouraging users to depend on the class in their tests.
-  
+
 * Respect options(warn = -1) to ignore all warnings (@jeroen #958).
 
 ## Expectations
@@ -788,33 +789,33 @@ This release mostly focusses on an overhaul of how testthat works with condition
 ## Other minor improvements and bug fixes
 
 * `compare.numeric()` uses a more sophisticated default tolerance that will
-  automatically skip tests that rely on numeric tolerance if long doubles are 
+  automatically skip tests that rely on numeric tolerance if long doubles are
   not available (#940).
 
-* `JunitReporter` now reports tests in ISO 8601 in the UTC timezone and 
+* `JunitReporter` now reports tests in ISO 8601 in the UTC timezone and
   uses the maximum precision of 3 decimal places (#923).
 
 # testthat 2.2.1
 
-* Repair regression in `test_rd()` and add a couple of tests to hopefully 
+* Repair regression in `test_rd()` and add a couple of tests to hopefully
   detect the problem earlier in the future.
 
 # testthat 2.2.0
 
 ## New features
 
-* New `verify_output()` is designed for testing output aimed at humans 
+* New `verify_output()` is designed for testing output aimed at humans
   (most commonly print methods and error messages). It is a regression
   test that saves output in a way that makes it easy to review. It is
   automatically skipped on CRAN (#782, #834).
 
 ## Minor improvements and bug fixes
 
-* `as.data.frame.testthat_results()` now always returns a data frame with 13 
+* `as.data.frame.testthat_results()` now always returns a data frame with 13
   columns (@jozefhajnala, #887).
 
-* `auto_test_package()` now correctly handles helper files 
-  (`tests/testthat/helper-*.R`), automatically reloading all code and 
+* `auto_test_package()` now correctly handles helper files
+  (`tests/testthat/helper-*.R`), automatically reloading all code and
   rerunning all tests (@CorradoLanera, #376, #896).
 
 * `expect_match()` now displays `info` even when match length is 0 (#867).
@@ -822,23 +823,23 @@ This release mostly focusses on an overhaul of how testthat works with condition
 * `expect_s3_class()` gains new `exact` argument that allows you to check
   for an exact class match, not just inheritance (#885).
 
-* `fail()` and `succeed()` gain `info` argument, which is passed along to 
+* `fail()` and `succeed()` gain `info` argument, which is passed along to
   `expect()`.
-  
-* `test_examples()` gets some minor fixes: it now returns the results 
-  invisibly, doesn't assume that examples should contain tests, and 
+
+* `test_examples()` gets some minor fixes: it now returns the results
+  invisibly, doesn't assume that examples should contain tests, and
   documents that you shouldn't be using it routinely (#841).
 
 * `test_file()` only calls `Reporter$end_context()` if a context was started,
   fixing an error in `TeamcityReporter` (@atheriel, #883).
 
-* `skip()` now reports reason for skipping as: `Reason: {skip condition}` 
+* `skip()` now reports reason for skipping as: `Reason: {skip condition}`
   (@patr1ckm, #868).
 
-* `skip_if()` and `skip_if_not()` now report `Reason: {skip condition} is TRUE` 
+* `skip_if()` and `skip_if_not()` now report `Reason: {skip condition} is TRUE`
   and `Reason: {skip condition} is not TRUE` respectively (@	patr1ckm, #868).
-  
-* `skip_if_translated()` now tests for translation of a specific message. 
+
+* `skip_if_translated()` now tests for translation of a specific message.
   This is more robust than the previous approach because translation
   happens message-by-message, not necessarily for the entire session (#879)
   (and in general, it's impossible to determine what language R is currently
@@ -846,7 +847,7 @@ This release mostly focusses on an overhaul of how testthat works with condition
 
 * `skip_on_covr()` allows you to skip tests when covr is running.
   (@ianmcook, #895)
-  
+
 * `expect_known_value()` gains a new serialisation `version` argument,
   defaulting to 2. Prevents the `.rds` files created to hold reference objects
   from making a package appear to require R >= 3.5 (#888 @jennybc).
@@ -882,8 +883,8 @@ This release mostly focusses on an overhaul of how testthat works with condition
 
 * `expect_error()` now returns the error object as documentated (#724).
   It also now warns if you're using a classed expectation and you're
-  not using the `class` argument. This is good practice as it decouples the 
-  error object (which tends to be stable) from its rendering to the user 
+  not using the `class` argument. This is good practice as it decouples the
+  error object (which tends to be stable) from its rendering to the user
   (which tends to be fragile) (#816).
 
 * `expect_identical()` gains a `...` argument to pass additional arguments
@@ -893,13 +894,13 @@ This release mostly focusses on an overhaul of how testthat works with condition
   and `NA` arguments appropriately (#732), and no longer require the inputs
   to be numeric.
 
-* `expect_output()` gains a `width` argument, allowing you to control the 
-  output width. This does not inherit from `getOption("width")`, ensuring 
+* `expect_output()` gains a `width` argument, allowing you to control the
+  output width. This does not inherit from `getOption("width")`, ensuring
   that tests return the same results regardless of environment (#805).
 
 * `expect_setequal()` now works with more vector types (including lists),
-  because it uses `%in%`, rather than `sort()`. It also warns if the inputs 
-  are named, as this suggests that your mental model of how `expect_setequal()` 
+  because it uses `%in%`, rather than `sort()`. It also warns if the inputs
+  are named, as this suggests that your mental model of how `expect_setequal()`
   works is wrong (#750).
 
 * `is_true()` and `is_false()` have been deprecated because they conflict
@@ -914,7 +915,7 @@ This release mostly focusses on an overhaul of how testthat works with condition
 * `JUnitReporter` no longer replaces `.` in class names (#753), and
   creates output that should be more compatible with Jenkins (#806, @comicfans).
 
-* `ListReporter` now records number of passed tests and original results in 
+* `ListReporter` now records number of passed tests and original results in
   new columns (#675).
 
 * `ProgressReporter`, the default reporter, now:
@@ -922,20 +923,20 @@ This release mostly focusses on an overhaul of how testthat works with condition
     * Automatically generates a context from the file name. We no longer
       recommend the use of `context()` and instead encourage you to delete it,
       allowing the context to be autogenerated from the file name.
-      
-      This also eliminates the error that occurred if tests can before the
-      first `context()` (#700, #705). 
 
-    * Gains a `update_interval` parameter to control how often updates are 
+      This also eliminates the error that occurred if tests can before the
+      first `context()` (#700, #705).
+
+    * Gains a `update_interval` parameter to control how often updates are
       printed (default 0.1 s). This prevents large printing overhead
       for very fast tests. (#701, @jimhester)
 
     * Uses a 3 character wide column to display test successes, so up to
-      999 successful tests can be displayed without changing the alignment 
+      999 successful tests can be displayed without changing the alignment
       (#712).
 
-* `reporter$end_reporter()` is now only called when testing completes 
-  successfully. This ensures that you don't get unnecessary output when the 
+* `reporter$end_reporter()` is now only called when testing completes
+  successfully. This ensures that you don't get unnecessary output when the
   test fails partway through (#727).
 
 ## Skips
@@ -943,7 +944,7 @@ This release mostly focusses on an overhaul of how testthat works with condition
 * `skip_if_offline()` skips tests if an internet connection is not available
   (#685).
 
-* `skip_on_ci()` skips tests on continuous integration systems 
+* `skip_on_ci()` skips tests on continuous integration systems
   (@mbjoseph, #825) by looking for a `CI` env var..
 
 ## Other new features
@@ -962,14 +963,14 @@ This release mostly focusses on an overhaul of how testthat works with condition
 
 * `expect_s3_class()` now works with unquoting (@jalsalam, #771).
 
-* `expectation` objects now contain the failure message, even when successful 
+* `expectation` objects now contain the failure message, even when successful
   (#836)
 
-* `devtools::test()` no longer fails if run multiple times within the same R 
+* `devtools::test()` no longer fails if run multiple times within the same R
   session for a package containing Catch tests.
   ([devtools #1832](https://github.com/r-lib/devtools/issues/1832))
 
-* New `testing_package()` retrieves the name of the package currently being 
+* New `testing_package()` retrieves the name of the package currently being
   tested (#699).
 
 * `run_testthat_tests` C entrypoint is registered more robustly.
@@ -977,7 +978,7 @@ This release mostly focusses on an overhaul of how testthat works with condition
 * `skip()` now always produces a `message` of length 1, as expected elsewhere
   in testthat (#791).
 
-* Warnings are passed through even when `options(warn = 2)` is set 
+* Warnings are passed through even when `options(warn = 2)` is set
   (@yutannihilation, #721).
 
 # testthat 2.0.1
@@ -988,16 +989,16 @@ This release mostly focusses on an overhaul of how testthat works with condition
 
 ## Breaking API changes
 
-* "Can't mock functions in base packages": You can no longer use `with_mock()` 
-  to mock functions in base packages, because this no longer works in 
+* "Can't mock functions in base packages": You can no longer use `with_mock()`
+  to mock functions in base packages, because this no longer works in
   R-devel due to changes with the byte code compiler. I recommend using
-  [mockery](https://github.com/r-lib/mockery) or 
+  [mockery](https://github.com/r-lib/mockery) or
   [mockr](https://github.com/krlmlr/mockr) instead.
 
 * The order of arguments to `expect_equivalent()` and `expect_error()` has
   changed slightly as both now pass `...` on another function. This reveals
   itself with a number of different errors, like:
-  
+
     * 'what' must be a character vector
     * 'check.attributes' must be logical
     * 'tolerance' should be numeric
@@ -1005,23 +1006,23 @@ This release mostly focusses on an overhaul of how testthat works with condition
     * threw an error with unexpected class
     * argument "quo" is missing, with no default
     * argument is missing, with no default
-    
-    If you see one of these errors, check the number, order, and names of 
+
+    If you see one of these errors, check the number, order, and names of
     arguments to the expectation.
 
-* "Failure: (unknown)". The last release mistakenly failed to test 
+* "Failure: (unknown)". The last release mistakenly failed to test
   bare expectations not wrapped inside `test_that()`. If you see "(unknown)"
   in a failure message, this is a failing expectation that you previously
   weren't seeing. As well as fixing the failure, please also wrap inside
   a `test_that()` with an informative name.
-  
-* "Error: the argument has already been evaluated": the way in which 
-  expectations now need create labels has changed, which caused a couple 
-  of failures with unusual usage when combined with `Reduce`, `lapply()`, 
+
+* "Error: the argument has already been evaluated": the way in which
+  expectations now need create labels has changed, which caused a couple
+  of failures with unusual usage when combined with `Reduce`, `lapply()`,
   and `Map()`. Avoid these functions in favour of for loops. I also recommend
-  reading the section below on quasiquotation support in order to create more 
+  reading the section below on quasiquotation support in order to create more
   informative failure messages.
-  
+
 ## Expectations
 
 ### New and improved expectations
@@ -1029,7 +1030,7 @@ This release mostly focusses on an overhaul of how testthat works with condition
 * `expect_condition()` works like `expect_error()` but captures any
   condition, not just error conditions (#621).
 
-* `expect_error()` gains a `class` argument that allows you to make an 
+* `expect_error()` gains a `class` argument that allows you to make an
   assertion about the class of the error object (#530).
 
 * `expect_reference()` checks if two names point to the same object (#622).
@@ -1047,7 +1048,7 @@ This release mostly focusses on an overhaul of how testthat works with condition
   where translations are likely to occur (#565). Use this to avoid
   spurious failures when checking the text of error messages in non-English
   locales.
-  
+
 * `skip_if_not_installed()` gains new `minimum_version` argument (#487, #499).
 
 ### Known good values
@@ -1056,14 +1057,14 @@ We have identified a useful family of expectations that compares the results of 
 
 * `expect_known_output()` replaces `expect_output_file()`, which has
   been soft-deprecated. It now defaults to `update = TRUE` and warn, rather
-  than failing on the first run. It gains a `print` argument to automatically 
-  print the input (#627). It also sets the width option to 80 to ensure 
+  than failing on the first run. It gains a `print` argument to automatically
+  print the input (#627). It also sets the width option to 80 to ensure
   consistent output across environments (#514)
 
 * `expect_known_value()` replaces `expect_equal_to_reference()`, which
   has been soft-deprecated. It gains an update argument defaulting to `TRUE`.
   This changes behaviour from the previous version, and soft-deprecated
-  `expect_equal_to_reference()` gets `update = FALSE`. 
+  `expect_equal_to_reference()` gets `update = FALSE`.
 
 * `expect_known_failure()` stored and compares the failure message from
   an expectation. It's a useful regression test when developing informative
@@ -1102,7 +1103,7 @@ If you unquote the values using `!!`, you get the failure message `` `f(4L)` not
 
 * New `setup()` and `teardown()` functions allow you to run at the start and
   end of each test file. This is useful if you want to pair cleanup code
-  with the code that messes up state (#536). 
+  with the code that messes up state (#536).
 
 * Two new prefixes are recognised in the `test/` directory. Files starting
   with `setup` are run before tests (but unlike `helpers` are not run in
@@ -1113,16 +1114,16 @@ If you unquote the values using `!!`, you get the failure message `` `f(4L)` not
 
 * All files are now read and written as UTF-8 (#510, #605).
 
-* `is_testing()` allows you to tell if your code is being run inside a 
+* `is_testing()` allows you to tell if your code is being run inside a
   testing environment (#631). Rather than taking a run-time dependency on testthat
   you may want to inline the function into your own package:
-  
+
     ```R
     is_testing <- function() {
       identical(Sys.getenv("TESTTHAT"), "true")
     }
     ```
-    
+
     It's frequently useful to combine with `interactive()`.
 
 ### New default reporter
@@ -1134,13 +1135,13 @@ A new default reporter, `ReporterProgress`, produces more aesthetically pleasing
 * Output colours have been tweaked to be consistent with clang:
   warnings are now in magenta, and skips in blue.
 
-* New `default_reporter()` and `check_reporter()` which returns the default 
+* New `default_reporter()` and `check_reporter()` which returns the default
   reporters for interactive and check environments (#504).
 
-* New `DebugReporter` that calls a better version of `recover()` in case of 
+* New `DebugReporter` that calls a better version of `recover()` in case of
   failures, errors, or warnings (#360, #470).
 
-* New `JunitReporter` generates reports in JUnit compatible format.  
+* New `JunitReporter` generates reports in JUnit compatible format.
   (#481, @lbartnik; #640, @nealrichardson; #575)
 
 * New `LocationReporter` which just prints the location of every expectation.
@@ -1148,23 +1149,23 @@ A new default reporter, `ReporterProgress`, produces more aesthetically pleasing
 
 * `SummaryReporter` received a number of smaller tweaks
 
-  * Aborts testing as soon the limit given by the option 
+  * Aborts testing as soon the limit given by the option
     `testthat.summary.max_reports` (default 10) is reached (#520).
-    
+
   * New option `testthat.summary.omit_dots = TRUE` hides the progress dots
     speeding up tests by a small amount (#502).
 
-  * Bring back random praise and encouragement which I accidentally dropped 
+  * Bring back random praise and encouragement which I accidentally dropped
     (#478).
 
-* New option `testthat.default_check_reporter`, defaults to `"check"`. 
+* New option `testthat.default_check_reporter`, defaults to `"check"`.
   Continuous Integration system can set this option before evaluating
   package test sources in order to direct test result details to known
   location.
 
-* All reporters now accept a `file` argument on initialization. If provided, 
-  reporters will write the test results to that path. This output destination 
-  can also be controlled with the option `testthat.output_file` 
+* All reporters now accept a `file` argument on initialization. If provided,
+  reporters will write the test results to that path. This output destination
+  can also be controlled with the option `testthat.output_file`
   (#635, @nealrichardson).
 
 ## Deprecated functions
@@ -1175,20 +1176,20 @@ A new default reporter, `ReporterProgress`, produces more aesthetically pleasing
 ## Minor improvements and bug fixes
 
 * Updated Catch to 1.9.6. `testthat` now understands and makes use of the package
-  routine registration mechanism required by CRAN with R >= 3.4.0. 
+  routine registration mechanism required by CRAN with R >= 3.4.0.
   (@kevinushey)
 
-* Better reporting for deeply nested failures, limiting the stack trace to the 
+* Better reporting for deeply nested failures, limiting the stack trace to the
   first and last 10 entries (#474).
 
-* Bare expectations notify the reporter once again. This is achieved by running 
-  all tests inside `test_code()` by default (#427, #498). This behaviour can be 
+* Bare expectations notify the reporter once again. This is achieved by running
+  all tests inside `test_code()` by default (#427, #498). This behaviour can be
   overridden by setting `wrap = FALSE` in `test_dir()` and friends (#586).
 
-* `auto_test()` and `auto_test_package()` provide `hash` parameter to enable 
+* `auto_test()` and `auto_test_package()` provide `hash` parameter to enable
   switching to faster, time-stamp-based modification detection
-  (#598, @katrinleinweber). `auto_test_package()` works correctly on windows 
-  (#465). 
+  (#598, @katrinleinweber). `auto_test_package()` works correctly on windows
+  (#465).
 
 * `capture_output_lines()` is now exported (#504).
 
@@ -1200,7 +1201,7 @@ A new default reporter, `ReporterProgress`, produces more aesthetically pleasing
 * `compare.numeric()` respects `check.attributes()` so `expect_equivalent()`
   correctly ignores attributes of numeric vectors (#485).
 
-* Output expectations (`expect_output()`, `expect_message()`, 
+* Output expectations (`expect_output()`, `expect_message()`,
   `expect_warning()`, and `expect_silent()`) all invisibly return the first
   argument to be consistent with the other expectations (#615).
 
@@ -1212,34 +1213,34 @@ A new default reporter, `ReporterProgress`, produces more aesthetically pleasing
   that forward to `expect_match()`, like `expect_output()`, `expect_message()`,
   `expect_warning()`, and `expect_error()`.
 
-* `expect_match()` escapes special regular expression characters when printing 
+* `expect_match()` escapes special regular expression characters when printing
   (#522, @jimhester).
 
 * `expect_message()`, `expect_warning()` and `expect_error()` produce clearer
   failure messages.
 
-* `find_test_scripts()` only looks for `\.[rR]` in the extension 
+* `find_test_scripts()` only looks for `\.[rR]` in the extension
   (#492, @brodieG)
-  
-* `test_dir()`, `test_package()`, `test_check()` unset the `R_TESTS` env var 
+
+* `test_dir()`, `test_package()`, `test_check()` unset the `R_TESTS` env var
   (#603)
 
 * `test_examples()` now works with installed packages as well as source
   packages (@jimhester, #532).
 
-* `test_dir()`, `test_package()`, and `test_check()` gain `stop_on_failure` 
-  and `stop_on_waring` arguments that control whether or not an error 
+* `test_dir()`, `test_package()`, and `test_check()` gain `stop_on_failure`
+  and `stop_on_waring` arguments that control whether or not an error
   is signalled if any tests fail or generate warnings (#609, #619).
 
 * `test_file()` now triggers a `gc()` after tests are run. This helps
   to ensure that finalisers are run earlier (#535).
 
-* `test_path()` now generates correct path when called from within 
+* `test_path()` now generates correct path when called from within
   `tools::testInstalledPackage()` (#542).
 
 * `test_path()` no longer assumes that the path exists (#448).
 
-* `test_that()` calls without any expectations generate a default `skip()` 
+* `test_that()` calls without any expectations generate a default `skip()`
   (#413).
 
 * `test_dir()` gains `load_helpers` argument  (#505).
@@ -1247,7 +1248,7 @@ A new default reporter, `ReporterProgress`, produces more aesthetically pleasing
 * `show_failures()` simply prints a failure if it occurs. This makes it easier
   to show failures in examples.
 
-* `with_mock()` disallows mocking of functions in base packages, because this 
+* `with_mock()` disallows mocking of functions in base packages, because this
   doesn't work with the current development version of R (#553).
 
 # testthat 1.0.2
@@ -1266,20 +1267,20 @@ A new default reporter, `ReporterProgress`, produces more aesthetically pleasing
 
 * Fixed an out-of-bounds memory access when routing Catch output
   through `Rprintf()`. (@kevinushey)
-  
+
 * Ensure that unit tests run on R-oldrel (remove use of `dir.exists()`).
   (@kevinushey)
-  
+
 * Improved overriding of calls to `exit()` within Catch, to ensure
   compatibility with GCC 6.0. (@krlmlr)
 
-* Hardened formatting of difference messages, previously the presence of `%` 
+* Hardened formatting of difference messages, previously the presence of `%`
   characters could affect the output (#446, @krlmlr).
-  
-* Fixed errors in `expect_equal()` when comparing numeric vectors with and 
+
+* Fixed errors in `expect_equal()` when comparing numeric vectors with and
   without attributes (#453, @krlmlr).
 
-* `auto_test()` and `auto_test_package()` show only the results of the 
+* `auto_test()` and `auto_test_package()` show only the results of the
   current test run and not of previously failed runs (#456, @krlmlr).
 
 # testthat 1.0.0
@@ -1293,11 +1294,11 @@ The `expectation()` function now expects an expectation type (one of "success", 
 The expectation system got a thorough overhaul (#217). This primarily makes it easier to add new expectations in the future, but also included a thorough review of the documentation, ensuring that related expectations are documented together, and have evocative names.
 
 One useful change is that most expectations invisibly return the input `object`. This makes it possible to chain together expectations with magrittr:
-    
+
 ```R
-factor("a") %>% 
-  expect_type("integer") %>% 
-  expect_s3_class("factor") %>% 
+factor("a") %>%
+  expect_type("integer") %>%
+  expect_s3_class("factor") %>%
   expect_length(1)
 ```
 
@@ -1310,7 +1311,7 @@ Another change is that `expect_output()` now requires you to explicitly print th
 
 There are six new expectations:
 
-* `expect_type()` checks the _type_ of the object (#316), 
+* `expect_type()` checks the _type_ of the object (#316),
   `expect_s3_class()` tests that an object is S3 with given class,
   `expect_s4_class()` tests that an object is S4 with given class (#373).
   I recommend using these more specific expectations instead of the
@@ -1343,19 +1344,19 @@ The reporters system class has been considerably refactored to make existing rep
 
 * Reporters classes are now R6 classes instead of Reference Classes.
 
-* Each callbacks receive the full context: 
+* Each callbacks receive the full context:
 
     * `add_results()` is passed context and test as well as the expectation.
     * `test_start()` and `test_end()` both get the context and test.
-    * `context_start()` and `context_end()` get the context. 
+    * `context_start()` and `context_end()` get the context.
 
 * Warnings are now captured and reported in most reporters.
 
 * The reporter output goes to the original standard output and is not affected by `sink()` and `expect_output()` (#420, @krlmlr).
 
 * The default summary reporter lists all warnings (#310), and all skipped
-  tests (@krlmlr, #343). New option `testthat.summary.max_reports` limits 
-  the number of reports printed by the summary reporter. The default is 15 
+  tests (@krlmlr, #343). New option `testthat.summary.max_reports` limits
+  the number of reports printed by the summary reporter. The default is 15
   (@krlmlr, #354).
 
 * `MinimalReporter` correct labels errors with E and failures with F (#311).
@@ -1365,8 +1366,8 @@ The reporters system class has been considerably refactored to make existing rep
 
 ## Other
 
-* New functions `capture_output()`, `capture_message()`, and 
-  `capture_warnings()` selectively capture function output. These are 
+* New functions `capture_output()`, `capture_message()`, and
+  `capture_warnings()` selectively capture function output. These are
   used in `expect_output()`, `expect_message()` and `expect_warning()`
   to allow other types out output to percolate up (#410).
 
@@ -1376,7 +1377,7 @@ The reporters system class has been considerably refactored to make existing rep
 * `test_file()`, `test_check()`, and `test_package()` now attach testthat so
   all testing functions are available.
 
-* `source_test_helpers()` gets a useful default path: the testthat tests 
+* `source_test_helpers()` gets a useful default path: the testthat tests
   directory. It defaults to the `test_env()` to be consistent with the
   other source functions (#415).
 
@@ -1397,24 +1398,24 @@ The reporters system class has been considerably refactored to make existing rep
 
 * `source_file()` exports the function testthat uses to load files from disk.
 
-* `test_that()` returns a `logical` that indicates if all tests were successful 
+* `test_that()` returns a `logical` that indicates if all tests were successful
   (#360, @krlmlr).
 
-* `find_reporter()` (and also all high-level testing functions) support a vector 
-  of reporters. For more than one reporter, a `MultiReporter` is created 
+* `find_reporter()` (and also all high-level testing functions) support a vector
+  of reporters. For more than one reporter, a `MultiReporter` is created
   (#307, @krlmlr).
 
-* `with_reporter()` is used internally and gains new argument 
+* `with_reporter()` is used internally and gains new argument
   `start_end_reporter = TRUE` (@krlmlr, 355).
 
 * `set_reporter()` returns old reporter invisibly (#358, @krlmlr).
 
-* Comparing integers to non-numbers doesn't raise errors anymore, and falls 
-  back to string comparison if objects have different lengths. Complex numbers 
+* Comparing integers to non-numbers doesn't raise errors anymore, and falls
+  back to string comparison if objects have different lengths. Complex numbers
   are compared using the same routine (#309, @krlmlr).
 
-* `compare.numeric()` and `compare.character()` received another overhaul. This 
-  should improve behaviour of edge cases, and provides a strong foundation for 
+* `compare.numeric()` and `compare.character()` received another overhaul. This
+  should improve behaviour of edge cases, and provides a strong foundation for
   further work. Added `compare.POSIXt()` for better reporting of datetime
   differences.
 
@@ -1441,14 +1442,14 @@ The reporters system class has been considerably refactored to make existing rep
 * Praise gets more diverse thanks to the praise package, and you'll now
   get random encouragement if your tests don't pass.
 
-* testthat no longer muffles warning messages. If you don't want to see them 
-  in your output, you need to explicitly quiet them, or use an expectation that 
+* testthat no longer muffles warning messages. If you don't want to see them
+  in your output, you need to explicitly quiet them, or use an expectation that
   captures them (e.g. `expect_warning()`). (#254)
 
 * Use tests in `inst/tests` is formally deprecated. Please move them into
   `tests/testthat` instead (#231).
 
-* `expect_match()` now encodes the match, as well as the output, in the 
+* `expect_match()` now encodes the match, as well as the output, in the
   expectation message (#232).
 
 * `expect_is()` gives better failure message when testing multiple inheritance,
@@ -1457,7 +1458,7 @@ The reporters system class has been considerably refactored to make existing rep
 * Corrected argument order in `compare.numeric()` (#294).
 
 * `comparison()` constructure now checks its arguments are the correct type and
-  length. This bugs a bug where tests failed with an error like "values must be 
+  length. This bugs a bug where tests failed with an error like "values must be
   length 1, but FUN(X[[1]]) result is length 2" (#279).
 
 * Added `skip_on_os()`, to skip tests on specified operating systems
@@ -1482,8 +1483,8 @@ The reporters system class has been considerably refactored to make existing rep
 
 * Deprecated `library_if_available()` has been removed.
 
-* test (`test_dir()`, `test_file()`, `test_package()`, `test_check()`) functions 
-  now return a `testthat_results` object that contains all results, and can be 
+* test (`test_dir()`, `test_file()`, `test_package()`, `test_check()`) functions
+  now return a `testthat_results` object that contains all results, and can be
   printed or converted to data frame.
 
 * `test_dir()`, `test_package()`, and `test_check()` have an added `...`
@@ -1518,7 +1519,7 @@ The reporters system class has been considerably refactored to make existing rep
 * `skip_on_travis()` allows you to skip tests when run on Travis CI.
   (Thanks to @mllg)
 
-* `colourise()` was removed. (Colour is still supported, via the `crayon` 
+* `colourise()` was removed. (Colour is still supported, via the `crayon`
   package.)
 
 * Mocks can now access values local to the call of `with_mock` (#193, @krlmlr).

--- a/R/expect-condition.R
+++ b/R/expect-condition.R
@@ -278,7 +278,7 @@ expect_condition_matching <- function(base_class,
   )
 
   expected <- !identical(regexp, NA)
-  msg <- compare_condition_3e(base_class, act$cap, act$lab, expected)
+  msg <- compare_condition_3e(base_class, class, act$cap, act$lab, expected)
 
   # Access error fields with `[[` rather than `$` because the
   # `$.Throwable` from the rJava package throws with unknown fields
@@ -375,10 +375,14 @@ capture_matching_condition <- function(expr, matches) {
 
 # Helpers -----------------------------------------------------------------
 
-compare_condition_3e <- function(cond_type, cond, lab, expected) {
+compare_condition_3e <- function(cond_type, cond_class, cond, lab, expected) {
   if (expected) {
     if (is.null(cond)) {
-      sprintf("%s did not throw the expected %s.", lab, cond_type)
+      if (is.null(cond_class)) {
+        sprintf("%s did not throw the expected %s.", lab, cond_type)
+      } else {
+        sprintf("%s did not throw a %s with class <%s>.", lab, cond_type, cond_class)
+      }
     } else {
       NULL
     }

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -89,7 +89,7 @@ expect_snapshot <- function(x,
   )
 
   # Use expect_error() machinery to confirm that error is as expected
-  msg <- compare_condition_3e("error", state$error, quo_label(x), error)
+  msg <- compare_condition_3e("error", NULL, state$error, quo_label(x), error)
   if (!is.null(msg)) {
     if (error) {
       expect(FALSE, msg, trace = state$error[["trace"]])
@@ -362,4 +362,3 @@ with_is_snapshotting <- function(code) {
   withr::local_envvar(TESTTHAT_IS_SNAPSHOT = "true")
   code
 }
-

--- a/tests/testthat/_snaps/expect-condition.md
+++ b/tests/testthat/_snaps/expect-condition.md
@@ -25,6 +25,10 @@
     Message: dispatched!
     Class:   foobar/rlang_error/error/condition
 
+# condition class is included in failure
+
+    `f1()` did not throw a condition with class <bar>.
+
 # unused arguments generate a warning
 
     Code

--- a/tests/testthat/test-expect-condition.R
+++ b/tests/testthat/test-expect-condition.R
@@ -149,6 +149,11 @@ test_that("captured condition is muffled", {
   expect_error(expect_condition(stop("Hi")), NA)
 })
 
+test_that("condition class is included in failure", {
+  f1 <- function() signal(class = "foo")
+  expect_snapshot_failure(expect_condition(f1(), class = "bar"))
+})
+
 test_that("only matching condition is captured, others bubble up", {
   f1 <- function() {
     message("Hi")


### PR DESCRIPTION
In `expect_condition()` and friends, when `class` is supplied and the expectation fails.

Fixes #1987