### PR TITLE
Update vendered catch.h file to remove C++20 deprecated function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# testthat 3.2.3.9000
+
+* Fixed use of the deprecated C++20 function `std::uncaught_exception()` 
+  in the vendored Catch C++ unit testing library [@tylermorganwall, #2047]
+
 # testthat 3.2.3
 
 * Fixed an issue where `expect_no_error(1)` was failing (#2037).

--- a/inst/include/testthat/vendor/catch.h
+++ b/inst/include/testthat/vendor/catch.h
@@ -8379,7 +8379,7 @@ namespace Catch {
     {}
 
     ScopedMessage::~ScopedMessage() {
-        if ( !std::uncaught_exception() ){
+        if ( std::uncaught_exceptions() == 0 ){
             getResultCapture().popScopedMessage(m_info);
         }
     }
@@ -8702,7 +8702,7 @@ namespace Catch {
     Section::~Section() {
         if( m_sectionIncluded ) {
             SectionEndInfo endInfo( m_info, m_assertions, m_timer.getElapsedSeconds() );
-            if( std::uncaught_exception() )
+            if( std::uncaught_exceptions() > 0  )
                 getResultCapture().sectionEndedEarly( endInfo );
             else
                 getResultCapture().sectionEnded( endInfo );


### PR DESCRIPTION
I have confirmed this update fixes issue #2047 on with rhub:

https://github.com/tylermorganwall/rayrender/actions/runs/13449546083/job/37581472753

Right now this is causing a compilation error on CRAN due to a deprecated function (https://cran.r-project.org/web/checks/check_results_rayrender.html) and this error will prevent any packages from using C++ catch.h unit tests.