### PR TITLE
Update vignette advice for migrating to {testthat} 3e

### DIFF
--- a/vignettes/parallel.Rmd
+++ b/vignettes/parallel.Rmd
@@ -111,10 +111,10 @@ The other built-in reporters all support parallel tests, with some subtle differ
     `ProgressReporter` does not update its display until a test file is complete.
 
 -   The standard output and standard error, i.e. `print()`, `cat()`, `message()`, etc. output from the test files are lost currently.
-    If you want to use `cat()` or `message()` for print-debugging test cases, then the best is to temporarily run tests sequentially, by changing the `Config` entry in `DESCRIPTION` or selecting a non-parallel reporter, e.g. the `CheckReporter`:
+    If you want to use `cat()` or `message()` for print-debugging test cases, then the best is to temporarily run tests sequentially, by changing the `Config` entry in `DESCRIPTION` or selecting a non-parallel reporter, e.g. the `DebugReporter`:
 
     ``` r
-    devtools::test(filter = "badtest", reporter = "check")
+    devtools::test(filter = "badtest", reporter = "debug")
     ```
 
 ### Writing parallel reporters

--- a/vignettes/third-edition.Rmd
+++ b/vignettes/third-edition.Rmd
@@ -82,7 +82,6 @@ Most of these functions have not been recommended for a number of years, but bef
     This was an overly clever API that I regretted even before the release of testthat 1.0.0.
 
 -   `expect_equivalent()` has been deprecated since it is now equivalent (HA HA) to `expect_equal(ignore_attr = TRUE)`.
-    The main difference is that it won't ignore names; so you'll need an explicit `unname()` if you deliberately want to ignore names.
 
 -   `setup()` and `teardown()` are deprecated in favour of test fixtures.
     See `vignette("test-fixtures")` for details.


### PR DESCRIPTION
I have recently been working on migrating some packages from {testthat} 2e to 3e. This PR updates a few places in the vignettes where I got confused.

First is the behavior of `expect_equal(ignore_attr = TRUE)`. From what I can decipher from the history, this initially ignored the attribute `names`. However, now it appears to ignore all attributes just like `expect_equivalent()`. I'm not sure exactly when this change occurred since this functionality was migrated to {waldo}.

```R
library("testthat")
packageVersion("testthat")
## [1] ‘3.2.3.9000’
edition_get()
## [1] 3

x1 <- x2 <- mtcars
colnames(x2) <- NULL
expect_equivalent(x1, x2)
## Warning message:
##   `expect_equivalent()` was deprecated in the 3rd edition.
## ℹ Use expect_equal(ignore_attr = TRUE)
expect_equal(x1, x2)
## Error: `x1` (`actual`) not equal to `x2` (`expected`).
##
## `names(actual)` is a character vector ('mpg', 'cyl', 'disp', 'hp', 'drat', ...)
## `names(expected)` is absent
expect_equal(x1, x2, ignore_attr = TRUE)
```

xref: https://github.com/r-lib/testthat/issues/1241, https://github.com/r-lib/testthat/pull/1422, https://github.com/r-lib/waldo/issues/97

Second is the advice for interactive debugging when the tests are configured to run in parallel. I wasn't able to use `browser()` with `CheckReporter` because it still ran the tests in parallel. I was able to use `browser()` with the `DebugReporter`.

````R
# Added browser() to first test in test-expect-condition.R

# CheckReporter
devtools::test(filter = "expect", reporter = "check")
## ℹ Testing testthat
## Starting 8 test processes
## [ FAIL 1 | WARN 0 | SKIP 1 | PASS 519 ]
## 
## ══ Skipped tests (1) ══════════════════════════════════════════════════════════════════════════════
## • On Windows (1): test-expect-known.R:46:3
## 
## ══ Failed tests ═══════════════════════════════════════════════════════════════════════════════════
## ── Error (test-expect-condition.R:2:3): returns condition or value ────────────────────────────────
## Error in `eval(code, test_env)`: non-interactive browser() -- left over from debugging?
## 
## [ FAIL 1 | WARN 0 | SKIP 1 | PASS 519 ]

# DebugReporter
devtools::test(filter = "expect", reporter = "debug")
## ℹ Testing testthat
## Called from: eval(code, test_env)
Browse[1]> 
```