### PR TITLE
Add tests for snapshots with different extensions

### DIFF
--- a/tests/testthat/_snaps/snapshot-manage.md
+++ b/tests/testthat/_snaps/snapshot-manage.md
@@ -3,56 +3,14 @@
     Code
       snapshot_accept(path = path)
     Message
-      Updating snapshots: 'a.md' and 'b.md'.
+      Updating snapshots: 'a.md' and 'test/b.txt'.
 
----
+# useful mesasge if no files to accept
 
     Code
       snapshot_accept(path = path)
     Message
       No snapshots to update.
-
-# can accept specific files
-
-    Code
-      snapshot_accept("a", path = path)
-    Message
-      Updating snapshots: 'a.md'.
-
----
-
-    Code
-      snapshot_accept("test/a.txt", path = path)
-    Message
-      Updating snapshots: 'test/a.txt'.
-
----
-
-    Code
-      snapshot_accept("test/", path = path)
-    Message
-      Updating snapshots: 'test/a.txt'.
-
----
-
-    Code
-      snapshot_accept("a", path = path)
-    Message
-      Updating snapshots: 'a.md'.
-
----
-
-    Code
-      snapshot_accept("b.txt", path = path)
-    Message
-      Updating snapshots: 'b.txt'.
-
----
-
-    Code
-      snapshot_accept("test/", path = path)
-    Message
-      Updating snapshots: 'test/a.md' and 'test/b.txt'.
 
 # can work with variants
 

--- a/tests/testthat/test-snapshot-manage.R
+++ b/tests/testthat/test-snapshot-manage.R
@@ -1,42 +1,58 @@
 test_that("informs about files being accepted", {
-  path <- local_snapshot_dir(c("a.md", "a.new.md", "b.md", "b.new.md"))
+  path <- local_snapshot_dir(c(
+    "a.md",
+    "a.new.md",
+    "test/b.txt",
+    "test/b.new.txt"
+  ))
 
   expect_snapshot(snapshot_accept(path = path))
-  expect_equal(dir(file.path(path, "_snaps")), c("a.md", "b.md"))
+  expect_equal(
+    dir(file.path(path, "_snaps"), recursive = TRUE),
+    c("a.md", "test/b.txt")
+  )
+})
 
+test_that("useful mesasge if no files to accept", {
+  path <- local_snapshot_dir(character())
   expect_snapshot(snapshot_accept(path = path))
 })
 
-test_that("can accept specific files", {
+test_that("can accept files created by expect_snapshot()", {
+  # without extension
   path <- local_snapshot_dir(c("a.md", "a.new.md", "b.md", "b.new.md"))
-  expect_snapshot(snapshot_accept("a", path = path))
+  suppressMessages(snapshot_accept("a", path = path))
   expect_equal(dir(file.path(path, "_snaps")), c("a.md", "b.md", "b.new.md"))
 
-  path <- local_snapshot_dir(c("test/a.txt", "test/a.new.txt"))
-  expect_snapshot(snapshot_accept("test/a.txt", path = path))
-  expect_equal(dir(file.path(path, "_snaps"), recursive = TRUE), "test/a.txt")
+  # with extension
+  path <- local_snapshot_dir(c("a.md", "a.new.md", "b.md", "b.new.md"))
+  suppressMessages(snapshot_accept("a.md", path = path))
+  expect_equal(dir(file.path(path, "_snaps")), c("a.md", "b.md", "b.new.md"))
 
   # or whole directory
+  path <- local_snapshot_dir(c("a.md", "a.new.md", "b.md", "b.new.md"))
+  suppressMessages(snapshot_accept(path = path))
+  expect_equal(dir(file.path(path, "_snaps")), c("a.md", "b.md"))
+})
+
+test_that("can accept files created by expect_snapshot_file()", {
   path <- local_snapshot_dir(c("test/a.txt", "test/a.new.txt"))
-  expect_snapshot(snapshot_accept("test/", path = path))
+  suppressMessages(snapshot_accept("test/a.txt", path = path))
   expect_equal(dir(file.path(path, "_snaps"), recursive = TRUE), "test/a.txt")
 
-  # snapshot files with different extensions
-  path <- local_snapshot_dir(c("a.md", "a.new.md", "b.txt", "b.new.txt"))
-  expect_snapshot(snapshot_accept("a", path = path))
-  expect_equal(dir(file.path(path, "_snaps")), c("a.md", "b.new.txt", "b.txt"))
+  # including markdown files
+  path <- local_snapshot_dir(c("test/a.md", "test/a.new.md"))
+  suppressMessages(snapshot_accept("test/", path = path))
+  expect_equal(dir(file.path(path, "_snaps"), recursive = TRUE), "test/a.md")
 
-  path <- local_snapshot_dir(c("a.md", "a.new.md", "b.txt", "b.new.txt"))
-  expect_snapshot(snapshot_accept("b.txt", path = path))
-  expect_equal(dir(file.path(path, "_snaps")), c("a.md", "a.new.md", "b.txt"))
-
+  # or the whole directory
   path <- local_snapshot_dir(c(
     "test/a.md",
     "test/a.new.md",
     "test/b.txt",
     "test/b.new.txt"
   ))
-  expect_snapshot(snapshot_accept("test/", path = path))
+  suppressMessages(snapshot_accept("test/", path = path))
   expect_equal(
     dir(file.path(path, "_snaps"), recursive = TRUE),
     c("test/a.md", "test/b.txt")


### PR DESCRIPTION
This adds two tests that pass on current `main` to help having a baseline for #2029. Following the discussion I've opened in #2106, we may add another test too (plus any other that may be suggested).