### PR TITLE
docs(expect_shape): Fix duplicate/missing param docs

### DIFF
--- a/R/expect-shape.R
+++ b/R/expect-shape.R
@@ -8,7 +8,7 @@
 #' @inheritParams expect_that
 #' @param ... Ignored.
 #' @param length Expected [length()] of `object`.
-#' @param nrow,nrow Expected [nrow()]/[ncol()] of `object`.
+#' @param nrow,ncol Expected [nrow()]/[ncol()] of `object`.
 #' @param dim Expected [dim()] of `object`.
 #' @family expectations
 #' @export

--- a/man/expect_shape.Rd
+++ b/man/expect_shape.Rd
@@ -16,15 +16,20 @@ within a function or for loop. See \link{quasi_label} for more details.}
 
 \item{length}{Expected \code{\link[=length]{length()}} of \code{object}.}
 
-\item{nrow}{Expected \code{\link[=nrow]{nrow()}} of \code{object}.}
-
-\item{ncol}{Expected \code{\link[=ncol]{ncol()}} of \code{object}.}
+\item{nrow, ncol}{Expected \code{\link[=nrow]{nrow()}}/\code{\link[=ncol]{ncol()}} of \code{object}.}
 
 \item{dim}{Expected \code{\link[=dim]{dim()}} of \code{object}.}
 }
 \description{
 This is a generalization of \code{\link[=expect_length]{expect_length()}} to test the "shape" of
 more general objects like data.frames, matrices, and arrays.
+}
+\examples{
+x <- matrix(1:9, nrow = 3)
+expect_shape(x, length = 9)
+expect_shape(x, nrow = 3)
+expect_shape(x, ncol = 3)
+expect_shape(x, dim = c(3, 3))
 }
 \seealso{
 \code{\link[=expect_length]{expect_length()}} to specifically make assertions about the


### PR DESCRIPTION
Error:
```
  Undocumented arguments in Rd file 'expect_shape.Rd'
    ‘ncol’
  Duplicated \argument entries in Rd file 'expect_shape.Rd':
    ‘nrow’
```