### PR TITLE
Strip ANSI escapes in `JunitReporter` `messages`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # testthat (development version)
 
+* `JunitReporter()` strips ANSI escapes in more placese (#1852, #2032).
 * `try_again()` is now publicised. The first argument is now the number of retries, not tries (#2050).
 * `vignette("custom-expectations)` has been overhauled to make it much clearer how to create high-quality expectations (#2113, #2132, #2072).
 * `expect_snapshot()` and friends will now fail when creating a new snapshot on CI. This is usually a signal that you've forgotten to run it locally before committing (#1461).

--- a/R/reporter-junit.R
+++ b/R/reporter-junit.R
@@ -120,7 +120,7 @@ JunitReporter <- R6::R6Class(
 
       first_line <- function(x) {
         loc <- expectation_location(x, " (", ")")
-        paste0(strsplit(x$message, split = "\n")[[1]][1], loc)
+        paste0(strsplit(cli::ansi_strip(x$message), split = "\n")[[1]][1], loc)
       }
 
       # add an extra XML child node if not a success

--- a/tests/testthat/test-reporter-junit.R
+++ b/tests/testthat/test-reporter-junit.R
@@ -7,3 +7,23 @@ test_that("permit Java-style class names", {
   class <- "package_name_or_domain.ClassName"
   expect_equal(classnameOK(class), class)
 })
+
+test_that("ANSI escapes are stripped from all user text in XML", {
+  skip_if_not_installed("xml2")
+
+  tmp <- withr::local_tempfile(fileext = ".xml")
+  reporter <- JunitReporterMock$new(file = tmp)
+  reporter$start_reporter()
+
+  text_with_ansi <- "\033[33mFirst line\033[0m\nSecond line"
+  reporter$start_context("c")
+  reporter$start_test("c", "t")
+  reporter$add_result("c", "t", new_expectation("error", text_with_ansi))
+  reporter$add_result("c", "t", new_expectation("failure", text_with_ansi))
+  reporter$add_result("c", "t", new_expectation("skip", text_with_ansi))
+  reporter$end_test()
+  reporter$end_context()
+  reporter$end_reporter()
+
+  expect_no_error(xml2::read_xml(tmp))
+})


### PR DESCRIPTION
Fixes #2032. Fixes #1852.