### PR TITLE
Return from snapshots, rather than skipping

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # testthat (development version)
 
+* `expect_snapshot()` no longer skips on CRAN, as that skips the rest of the test. Instead it just returns, neither succeeding nor failing (#1585).
 * Interrupting a test now prints the test name. This makes it easier to tell where a very slow test might be hanging (#1464)
 * Parallel testthat now does not ignore test files with syntax errors (#1360).
 * `expect_lt()`, `expect_gt()`, and friends have a refined display that is more likely to display the correct number of digits and shows you the actual values compared.

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -313,7 +313,7 @@ expect_snapshot_helper <- function(
   trace_env = caller_env()
 ) {
   if (!cran && on_cran()) {
-    skip("On CRAN")
+    return(invisible())
   }
 
   snapshotter <- get_snapshotter()

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -211,3 +211,14 @@ test_that("expect_snapshot_warning validates its inputs", {
     expect_snapshot_warning(warning("!"), cran = "yes")
   })
 })
+
+test_that("on CRAN, snapshots are not run but don't skill entire test", {
+  local_on_cran(TRUE)
+
+  expectations <- capture_expectations(test_that("", {
+    expect_snapshot(1 + 1)
+    expect_true(TRUE)
+  }))
+  expect_length(expectations, 1)
+  expect_s3_class(expectations[[1]], "expectation_success")
+})


### PR DESCRIPTION
Because skipping causes the rest of the test not to run. I'm not sure what we should do instead, so I just return; this will still cause a skip to be emitted if no other expectations are run within the test.

Fixes #1585