### PR TITLE
Correctly accept snapshots generated by dotted test names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # testthat (development version)
 
+* `snapshot_accept(test)` now works when the test file name contains `.` (#1669).
 * `local_mock()` and `with_mock()` have been deprecated because they are no longer permitted in R 4.5.
 * `snapshot_review()` now passes `...` on to `shiny::runApp()` (#1928).
 * `expect_named()` now gives more informative errors (#2091).

--- a/R/snapshot-manage.R
+++ b/R/snapshot-manage.R
@@ -196,7 +196,8 @@ snapshot_meta <- function(files = NULL, path = "tests/testthat") {
     files <- files[!is_dir]
 
     dirs <- substr(dirs, 1, nchar(dirs) - 1)
-    files <- ifelse(tools::file_ext(files) == "", paste0(files, ".md"), files)
+    # Match regardless of whether user include .md or not
+    files <- c(files, paste0(files, ".md"))
 
     out <- out[out$name %in% files | out$test %in% dirs, , drop = FALSE]
   }

--- a/tests/testthat/test-snapshot-manage.R
+++ b/tests/testthat/test-snapshot-manage.R
@@ -35,6 +35,20 @@ test_that("can accept files created by expect_snapshot()", {
   expect_equal(dir(file.path(path, "_snaps")), c("a.md", "b.md"))
 })
 
+test_that("can accept files created by dotted tests in name", {
+  # e.g. test-data.frame.R will create _snaps/data.frame.md
+
+  # without extension
+  path <- local_snapshot_dir(c("data.frame.md", "data.frame.new.md"))
+  suppressMessages(snapshot_accept("data.frame", path = path))
+  expect_equal(dir(file.path(path, "_snaps")), "data.frame.md")
+
+  # with extension
+  path <- local_snapshot_dir(c("data.frame.md", "data.frame.new.md"))
+  suppressMessages(snapshot_accept("data.frame.md", path = path))
+  expect_equal(dir(file.path(path, "_snaps")), "data.frame.md")
+})
+
 test_that("can accept files created by expect_snapshot_file()", {
   path <- local_snapshot_dir(c("test/a.txt", "test/a.new.txt"))
   suppressMessages(snapshot_accept("test/a.txt", path = path))


### PR DESCRIPTION
Fixes #1669