### PR TITLE
Improve unpredictable parallel stdout test case

### DIFF
--- a/tests/testthat/test-parallel-stdout.R
+++ b/tests/testthat/test-parallel-stdout.R
@@ -1,32 +1,26 @@
 test_that("stdout/stderr in parallel code", {
   skip_on_covr()
   withr::local_envvar(TESTTHAT_PARALLEL = "TRUE")
-  out <- capture.output(suppressMessages(testthat::test_local(
-    test_path("test-parallel", "stdout"),
-    reporter = "summary"
-  )))
-  expect_match(
-    out,
-    "> test-stdout-2.R: This is a message!",
-    fixed = TRUE,
-    all = FALSE
-  )
-  expect_match(out, "test-stdout-3.R:  [1]  1  2  3", fixed = TRUE, all = FALSE)
 
-  out2 <- capture.output(suppressMessages(testthat::test_local(
-    test_path("test-parallel", "stdout"),
-    reporter = "progress"
-  )))
-  expect_match(
-    out2,
-    "> test-stdout-2.R: This is a message!",
-    fixed = TRUE,
-    all = FALSE
-  )
-  expect_match(
-    out2,
-    "test-stdout-3.R:  [1]  1  2  3",
-    fixed = TRUE,
-    all = FALSE
-  )
+  assemble_msgs <- function(txt, test_name) {
+    prefix <- paste0("> ", test_name, ": ")
+    parts <- sub(
+      prefix,
+      "",
+      grep(prefix, out, fixed = TRUE, value = TRUE),
+      fixed = TRUE
+    )
+    paste(parts, collapse = "")
+  }
+
+  for (reporter in c("summary", "progress")) {
+    out <- capture.output(suppressMessages(testthat::test_local(
+      test_path("test-parallel", "stdout"),
+      reporter = reporter
+    )))
+    msg2 <- assemble_msgs(out, "test-stdout-2.R")
+    expect_match(msg2, "This is a message!", fixed = TRUE)
+    msg3 <- assemble_msgs(out, "test-stdout-3.R")
+    expect_match(msg3, "[1]  1  2  3", fixed = TRUE)
+  }
 })


### PR DESCRIPTION
Assemble messages from each worker separately before testing.