### PR TITLE
Handle errors in parallel teardown files

### DIFF
--- a/tests/testthat/test-parallel-teardown.R
+++ b/tests/testthat/test-parallel-teardown.R
@@ -1,5 +1,4 @@
 test_that("teardown error", {
-  skip("teardown errors are ignored")
   withr::local_envvar(TESTTHAT_PARALLEL = "TRUE")
   err <- tryCatch(
     capture.output(suppressMessages(testthat::test_local(
@@ -8,6 +7,14 @@ test_that("teardown error", {
     ))),
     error = function(e) e
   )
-  expect_s3_class(err, "testthat_process_error")
-  expect_match(err$message, "Error in teardown", fixed = TRUE)
+  expect_s3_class(err$parent, "callr_error")
+  expect_match(
+    err$message,
+    "At least one parallel worker failed to run teardown"
+  )
+  expect_match(
+    err$parent$parent$parent$message,
+    "Error in teardown",
+    fixed = TRUE
+  )
 })


### PR DESCRIPTION
I also changed the exit status of the subprocesses to 0 (normal exit),
from 1. I didn't find any reason why it was 1, hopefully there
wasn't any. It is a normal exit, so 0 makes more senset to me (now).

Closes #1165.