### PR TITLE
Fix the lister when running in parallel

### DIFF
--- a/tests/testthat/_snaps/reporter-list.md
+++ b/tests/testthat/_snaps/reporter-list.md
@@ -1,0 +1,10 @@
+# works in parallel
+
+    Code
+      results[, c(1:8, 12:13)]
+    Output
+        file context test nb failed skipped error warning passed         result
+      1   f1          t11  2      0   FALSE FALSE       0      2 msg111, msg112
+      2   f2          t21  2      0   FALSE FALSE       0      2 msg211, msg212
+      3   f2          t22  1      0    TRUE FALSE       0      0        skip221
+

--- a/tests/testthat/test-reporter-list.R
+++ b/tests/testthat/test-reporter-list.R
@@ -70,3 +70,45 @@ test_that("ListReporter and bare expectations", {
   # 2 tests, "before" and "after". no result for the bare expectation
   expect_identical(df$test, c("before", "after"))
 })
+
+test_that("works in parallel", {
+  lr <- ListReporter$new()
+
+  lr$start_file("f1")
+  lr$start_test(NULL, "t11")
+  lr$add_result(NULL, "t11", new_expectation("success", "msg111"))
+
+  lr$start_file("f2")
+  lr$start_test(NULL, "t21")
+  lr$add_result(NULL, "t21", new_expectation("success", "msg211"))
+
+  lr$start_file("f1")
+  lr$start_test(NULL, "t11")
+  lr$add_result(NULL, "t11", new_expectation("success", "msg112"))
+  lr$end_test(NULL, "t11")
+
+  lr$start_file("f2")
+  lr$start_test(NULL, "t21")
+  lr$add_result(NULL, "t21", new_expectation("success", "msg212"))
+  lr$end_test(NULL, "t21")
+
+  lr$start_file("f2")
+  lr$start_test(NULL, "t22")
+  lr$add_result(NULL, "t22", new_expectation("skip", "skip221"))
+  lr$end_test(NULL, "t22")
+
+  lr$start_file("f2")
+  lr$end_file()
+
+  lr$start_file("f1")
+  lr$end_file()
+
+  results <- as.data.frame(lr$get_results())
+  expect_snapshot({
+    results[, c(1:8, 12:13)]
+  })
+
+  expect_true(all(!is.na(results$user)))
+  expect_true(all(!is.na(results$system)))
+  expect_true(all(!is.na(results$real)))
+})


### PR DESCRIPTION
It was not prepared for receiving updates from multiple files concurrently and some results were lost.