### PR TITLE
Add `required` argument to expect_true

### DIFF
--- a/man/logical-expectations.Rd
+++ b/man/logical-expectations.Rd
@@ -6,7 +6,12 @@
 \alias{expect_false}
 \title{Do you expect \code{TRUE} or \code{FALSE}?}
 \usage{
-expect_true(object, info = NULL, label = NULL)
+expect_true(
+  object,
+  info = NULL,
+  label = NULL,
+  required = c("one", "any", "all")
+)
 
 expect_false(object, info = NULL, label = NULL)
 }
@@ -21,6 +26,10 @@ is soft-deprecated and should not be used in new code. Instead see
 alternatives in \link{quasi_label}.}
 
 \item{label}{Used to customise failure messages. For expert use only.}
+
+\item{required}{"one" (default) to require an identical match to \code{TRUE}.
+"any" to replicate \code{expect_true(any(TRUE))}. "all" for
+\code{expect_true(all(TRUE))}.}
 }
 \description{
 These are fall-back expectations that you can use when none of the other

--- a/tests/testthat/_snaps/expect-constant.md
+++ b/tests/testthat/_snaps/expect-constant.md
@@ -31,3 +31,59 @@
       `actual` is an S3 object of class <data.frame>, a list
       `expected` is NULL
 
+# expect_true(required = 'all')
+
+    Code
+      expect_true(FALSE, required = "all")
+    Condition
+      Error:
+      ! FALSE is not TRUE at index: 1
+
+---
+
+    Code
+      expect_true(c(FALSE, FALSE), required = "all")
+    Condition
+      Error:
+      ! `c(FALSE, FALSE)` is not TRUE at index: 1, 2
+
+---
+
+    Code
+      expect_true(c(TRUE, FALSE), required = "all")
+    Condition
+      Error:
+      ! `c(TRUE, FALSE)` is not TRUE at index: 2
+
+---
+
+    Code
+      expect_true("not logical", required = "all")
+    Condition
+      Error:
+      ! "not logical" is not TRUE at index: 1
+
+# expect_true(required = 'any')
+
+    Code
+      expect_true(FALSE, required = "any")
+    Condition
+      Error:
+      ! No values in FALSE are TRUE.
+
+---
+
+    Code
+      expect_true(c(FALSE, FALSE), required = "any")
+    Condition
+      Error:
+      ! No values in `c(FALSE, FALSE)` are TRUE.
+
+---
+
+    Code
+      expect_true("not logical", required = "any")
+    Condition
+      Error in `expect_true_any()`:
+      ! "not logical" must be a logical vector
+

--- a/tests/testthat/test-expect-constant.R
+++ b/tests/testthat/test-expect-constant.R
@@ -27,6 +27,65 @@ test_that("expect_null works", {
 })
 
 test_that("returns the input value", {
-  res <- expect_true(TRUE)
-  expect_equal(res, TRUE)
+  res_one <- expect_true(TRUE, required = "one")
+  expect_equal(res_one, TRUE)
+
+  res_any <- expect_true(TRUE, required = "any")
+  expect_equal(res_any, TRUE)
+
+  res_all <- expect_true(TRUE, required = "all")
+  expect_equal(res_all, TRUE)
+})
+
+test_that("expect_true(required = 'all')", {
+  expect_success(
+    expect_true(TRUE, required = "all")
+  )
+  expect_success(
+    expect_true(c(TRUE, TRUE), required = "all")
+  )
+
+  expect_snapshot_failure(
+    expect_true(FALSE, required = "all")
+  )
+  expect_snapshot_failure(
+    expect_true(c(FALSE, FALSE), required = "all")
+  )
+  expect_snapshot_failure(
+    expect_true(c(TRUE, FALSE), required = "all")
+  )
+  expect_snapshot_failure(
+    expect_true("not logical", required = "all")
+  )
+  expect_failure(
+    expect_true(c(TRUE, FALSE), required = "all", label = "FOO"),
+    "FOO"
+  )
+})
+
+test_that("expect_true(required = 'any')", {
+  expect_success(
+    expect_true(TRUE, required = "any")
+  )
+  expect_success(
+    expect_true(c(TRUE, TRUE), required = "any")
+  )
+  expect_success(
+    expect_true(c(FALSE, TRUE), required = "any")
+  )
+
+  expect_snapshot_failure(
+    expect_true(FALSE, required = "any")
+  )
+  expect_snapshot_failure(
+    expect_true(c(FALSE, FALSE), required = "any")
+  )
+  expect_snapshot_failure(
+    expect_true("not logical", required = "any")
+  )
+  # Label works
+  expect_failure(
+    expect_true(c(FALSE, FALSE), required = "any", label = "FOO"),
+    "FOO"
+  )
 })


### PR DESCRIPTION
Adds `required` argument to `expect_true()` that accepts `c("one", "any", "all")`. I've held off implementing for `expect_false` until we make sure the implementation is sound for easier review. This also means the docstring is slightly out of sync between `expect_true` and `expect_false` for now (and indeed the language could be a little nicer--I expect to polish this up too once we're aligned on the approach).

When `required = "any"` we throw an error to avoid edges with numeric vectors that contain `1` which may be coerced to `TRUE`.

Fixes #1836.