### PR TITLE
`expect_mapequal()` needs to set tolerance

### DIFF
--- a/R/expect-setequal.R
+++ b/R/expect-setequal.R
@@ -109,7 +109,7 @@ expect_mapequal <- function(object, expected) {
     } else {
       if (edition_get() >= 3) {
         act <- labelled_value(act$val[exp_nms], act$lab)
-        expect_waldo_equal_("equal", act, exp)
+        expect_waldo_equal_("equal", act, exp, tolerance = testthat_tolerance())
       } else {
         # Packages depend on 2e behaviour, but the expectation isn't written
         # to be reused, and we don't want to bother

--- a/tests/testthat/test-expect-setequal.R
+++ b/tests/testthat/test-expect-setequal.R
@@ -94,6 +94,10 @@ test_that("warns if empty vector", {
   expect_snapshot(expect_success(expect_mapequal(list(), list())))
 })
 
+test_that("ignores integer/numeric differences", {
+  expect_success(expect_mapequal(list(a = 1L), list(a = 1)))
+})
+
 test_that("uses equality behaviour of current edition", {
   local_edition(2)
   expect_success(expect_mapequal(c(a = 1), c(a = 1L)))


### PR DESCRIPTION
To preserve same behaviour as previously