### PR TITLE
Advance deprecations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # testthat (development version)
 
+* `expect_snapshot(binary)` is now fully deprecated; it was soft deprecated in v3.0.3.
+* `test_files(wrap)` has now been removed; it was deprecated in v3.0.0.
 * Make `expect_lt()`, `expect_lte()`, `expect_gt()`, and `expect_gte()` work properly for non-numeric data (#2268)
 * New `expect_disjoint()` to check for the absence of values (@stibu81, #1851).
 * `expect_all_equal()`, `expect_all_true()`, and `expect_all_false()` are a new family of expectations that checks that every element of a vector has the same value. Compared to using `expect_true(all(...))` they give better failure messages (#1836, #2235).

--- a/R/snapshot-file.R
+++ b/R/snapshot-file.R
@@ -137,7 +137,7 @@ expect_snapshot_file <- function(
 
   is_text <- is_text_file(name)
   if (!is_missing(binary)) {
-    lifecycle::deprecate_soft(
+    lifecycle::deprecate_warn(
       "3.0.3",
       "expect_snapshot_file(binary = )",
       "expect_snapshot_file(compare = )"

--- a/R/test-files.R
+++ b/R/test-files.R
@@ -36,7 +36,6 @@
 #'     ```
 #'     Config/testthat/load-all: list(export_all = FALSE, helpers = FALSE)
 #'     ```
-#' @param wrap DEPRECATED
 #' @return A list (invisibly) containing data about the test results.
 #' @inheritParams with_reporter
 #' @inheritParams source_file
@@ -50,7 +49,6 @@ test_dir <- function(
   load_helpers = TRUE,
   stop_on_failure = TRUE,
   stop_on_warning = FALSE,
-  wrap = deprecated(),
   package = NULL,
   load_package = c("none", "installed", "source"),
   shuffle = FALSE
@@ -67,10 +65,6 @@ test_dir <- function(
   )
   if (length(test_paths) == 0) {
     cli::cli_abort("No test files found.")
-  }
-
-  if (!is_missing(wrap)) {
-    lifecycle::deprecate_stop("3.0.0", "test_dir(wrap = )")
   }
 
   want_parallel <- find_parallel(path, load_package, package)
@@ -150,15 +144,11 @@ test_files <- function(
   stop_on_failure = FALSE,
   stop_on_warning = FALSE,
   desc = NULL,
-  wrap = TRUE,
   load_package = c("none", "installed", "source"),
   parallel = FALSE,
   shuffle = FALSE,
   error_call = caller_env()
 ) {
-  if (!isTRUE(wrap)) {
-    lifecycle::deprecate_stop("3.0.0", "test_dir(wrap = )")
-  }
 
   # Must keep these two blocks in sync
   if (parallel) {
@@ -202,7 +192,6 @@ test_files_serial <- function(
   stop_on_failure = FALSE,
   stop_on_warning = FALSE,
   desc = NULL,
-  wrap = TRUE,
   load_package = c("none", "installed", "source"),
   shuffle = FALSE,
   error_call = caller_env()

--- a/man/test_dir.Rd
+++ b/man/test_dir.Rd
@@ -13,7 +13,6 @@ test_dir(
   load_helpers = TRUE,
   stop_on_failure = TRUE,
   stop_on_warning = FALSE,
-  wrap = deprecated(),
   package = NULL,
   load_package = c("none", "installed", "source"),
   shuffle = FALSE
@@ -42,8 +41,6 @@ See \link{Reporter} for more details and a list of built-in reporters.}
 
 \item{stop_on_warning}{If \code{TRUE}, throw an error if any tests generate
 warnings.}
-
-\item{wrap}{DEPRECATED}
 
 \item{package}{If these tests belong to a package, the name of the package.}
 


### PR DESCRIPTION
Can't yet remove `is_informative_error()` because vctrs still registers methods for it.