### PR TITLE
Clarify caller_env is from rlang

### DIFF
--- a/vignettes/custom-expectation.Rmd
+++ b/vignettes/custom-expectation.Rmd
@@ -275,7 +275,7 @@ expect_s3_object <- function(object, class = NULL) {
 
 As you write more expectations, you might discover repeated code that you want to extract into a helper. Unfortunately, creating 100% correct helper functions is not straightforward in testthat because `fail()` captures the calling environment in order to give useful tracebacks, and testthat's own expectations don't expose this as an argument. Fortunately, getting this right is not critical (you'll just get a slightly suboptimal traceback in the case of failure), so we don't recommend bothering in most cases. We document it here, however, because it's important to get it right in testthat itself.
 
-The key challenge is that `fail()` captures a `trace_env`, which should be the execution environment of the expectation. This usually works because the default value of `trace_env` is `caller_env()`. But when you introduce a helper, you'll need to explicitly pass it along:
+The key challenge is that `fail()` captures a `trace_env`, which should be the execution environment of the expectation. This usually works because the default value of `trace_env` is `rlang::caller_env()`. But when you introduce a helper, you'll need to explicitly pass it along:
 
 ```{r}
 expect_length_ <- function(act, n, trace_env = caller_env()) {


### PR DESCRIPTION
Just bit by this:

https://github.com/r-lib/lintr/actions/runs/19476159740/job/55736370297?pr=2967

And first guessed `testthat::caller_env()`. I think this little nudge is enough. We could also move it to the formals of `expect_length_` below.