### PR TITLE
Use `expect_snapshot()` for vctrs error

### DIFF
--- a/tests/testthat/test-expect-vector.R
+++ b/tests/testthat/test-expect-vector.R
@@ -4,10 +4,14 @@ test_that("basic properties upheld", {
   expect_success(expect_vector(1:10, size = 10))
 
   x <- 1:10
-  expect_snapshot_failure(expect_vector(x, size = 5))
+  expect_snapshot(error = TRUE, {
+    expect_vector(x, size = 5)
+  })
 
   y <- NULL
-  expect_snapshot_failure(expect_vector(y))
+  expect_snapshot(error = TRUE, {
+    expect_vector(y)
+  })
 })
 
 test_that("expect_vector validates its inputs", {


### PR DESCRIPTION
We are planning a vctrs release for Jan 15.

A vctrs error related to "vectorness" has now changing, adding a link to a FAQ

This gives the following failure

```
── Failure (test-expect-vector.R:12:3): basic properties upheld ─────────────────────────────────────────────
Snapshot of code has changed:
old[3:5] vs new[3:6]
    expect_vector(y)
  Condition
    Error:
    ! `y` must be a vector, not `NULL`.
+   i Read our FAQ about scalar types (`?vctrs::faq_error_scalar_type`) to learn more.
``` 

We aren't testing `expect_snapshot_failure()` here, we are testing `expect_vector()`, so the simplest switch is to just use `expect_snapshot()`, which won't fail on CRAN when this error changes to what you see above. This makes sense to me because testthat doesn't own this error message.

But we may want to consider not relying on the vctrs messaging at all? Not sure.