### PR TITLE
Polish `snapshot_download_gh()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # testthat 3.3.1
 
+* The hint to use `snapshot_download_gh()` is now only emitted when running in a job named "R-CMD-check" (#2300).
 * `expect_snapshot_file()` correctly reports file name if duplicated (@MichaelChirico, #2296).
 * Fixed support for `shinytest2::AppDriver$expect_values()` screenshot snapshot failing on CI (#2293, #2288).
 

--- a/R/reporter-check.R
+++ b/R/reporter-check.R
@@ -123,7 +123,7 @@ summary_line <- function(n_fail, n_warn, n_skip, n_pass) {
 snapshot_check_hint <- function() {
   intro <- "To review and process snapshots locally:"
 
-  if (on_gh()) {
+  if (on_gh() && Sys.getenv("GITHUB_JOB") == "R-CMD-check") {
     repository <- Sys.getenv("GITHUB_REPOSITORY")
     run_id <- Sys.getenv("GITHUB_RUN_ID")
 

--- a/R/snapshot-github.R
+++ b/R/snapshot-github.R
@@ -7,7 +7,9 @@
 #' take the artifacts from.
 #'
 #' Note that you should not generally need to use this function manually;
-#' instead copy and paste from the hint emitted on GitHub.
+#' instead copy and paste from the hint emitted on GitHub. This hint is only
+#' emitted when running in a job named "R-CMD-check", since that's where the
+#' testthat artifact is typically uploaded.
 #'
 #' @param repository Repository owner/name, e.g. `"r-lib/testthat"`.
 #' @param run_id Run ID, e.g. `"47905180716"`. You can find this in the action url.

--- a/man/snapshot_download_gh.Rd
+++ b/man/snapshot_download_gh.Rd
@@ -11,7 +11,7 @@ snapshot_download_gh(repository, run_id, dest_dir = ".")
 
 \item{run_id}{Run ID, e.g. \code{"47905180716"}. You can find this in the action url.}
 
-\item{dest_dir}{Directory to download to. Defaults to the current directory.}
+\item{dest_dir}{Package root directory. Defaults to the current directory.}
 }
 \description{
 If your snapshots fail on GitHub, it can be a pain to figure out exactly
@@ -20,5 +20,7 @@ easy, only requiring you to interactively select which job you want to
 take the artifacts from.
 
 Note that you should not generally need to use this function manually;
-instead copy and paste from the hint emitted on GitHub.
+instead copy and paste from the hint emitted on GitHub. This hint is only
+emitted when running in a job named "R-CMD-check", since that's where the
+testthat artifact is typically uploaded.
 }

--- a/tests/testthat/test-reporter-check.R
+++ b/tests/testthat/test-reporter-check.R
@@ -44,7 +44,8 @@ test_that("generates informative snapshot hints", {
   withr::local_envvar(
     GITHUB_ACTIONS = "true",
     GITHUB_REPOSITORY = "r-lib/testthat",
-    GITHUB_RUN_ID = "123"
+    GITHUB_RUN_ID = "123",
+    GITHUB_JOB = "R-CMD-check"
   )
   expect_snapshot(base::writeLines(snapshot_check_hint()))
 })


### PR DESCRIPTION
* Clarify meaning of `dest_dir`.
* Only emit hint in `R-CMD-check` jobs.

Fixes #2300