### PR TITLE
Restore pre-3.3 `local_snapshotter()` argument order

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * `expect_snapshot()` and friends only emit the `snapshot_download_gh()` hint when running in a job named "R-CMD-check" (#2300).
 * `expect_snapshot_file()` correctly reports file name if duplicated (@MichaelChirico, #2296).
 * `expect_success()` and `expect_failure()` are more clear about what the expectation actually did (#2297).
+* `local_snapshotter()` now returns to `snap_dir` as the first argument for compatibility with devtools 2.4.6.
 * `LlmReporter()` is a new reporter designed for LLMs to read. It's currently used automatically inside Claude Code, Cursor, and Gemini CLI, and you can set `AGENT=1` to use with any coding agent (#2287).
 * `local_mocked_s3_method()` and `local_mocked_s4_method()` can now mock methods that don't already exist, and can use `definition = NULL` to temporarily remove a method. `local_mocked_s4_method()` now also works when the generic is defined in another package (#2302).
 * `test_dir()` will no longer run tests in parallel if only a single file is being tested (#2305).

--- a/R/snapshot-reporter.R
+++ b/R/snapshot-reporter.R
@@ -231,8 +231,8 @@ get_snapshotter <- function() {
 #' @export
 #' @keywords internal
 local_snapshotter <- function(
-  reporter = SnapshotReporter,
   snap_dir = "_snaps",
+  reporter = SnapshotReporter,
   cleanup = FALSE,
   desc = NULL,
   fail_on_new = NULL,

--- a/R/test-files.R
+++ b/R/test-files.R
@@ -318,7 +318,7 @@ test_files_reporter <- function(
     snap_base <- SnapshotReporter
   }
   snap <- local_snapshotter(
-    snap_base,
+    reporter = snap_base,
     fail_on_new = on_ci(),
     desc = desc,
     frame = frame

--- a/man/local_snapshotter.Rd
+++ b/man/local_snapshotter.Rd
@@ -5,8 +5,8 @@
 \title{Instantiate local snapshotting context}
 \usage{
 local_snapshotter(
-  reporter = SnapshotReporter,
   snap_dir = "_snaps",
+  reporter = SnapshotReporter,
   cleanup = FALSE,
   desc = NULL,
   fail_on_new = NULL,


### PR DESCRIPTION
Part of https://github.com/r-lib/devtools/pull/2631