### PR TITLE
Fix snapshot_accept/review filtering with variant snapshots

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # testthat (development version)
 
+* `snapshot_accept()`, `snapshot_reject()`, and `snapshot_review()` now correctly
+  find changed snapshots in variant subdirectories when filtering by test file
+  name (#2325).
 * `run_cpp_tests()` no longer accidentally reports that a test has been skipped (#2315).
 * `expect_setequal()` uses better wording in the results (@mcol, #2310).
 

--- a/R/snapshot-manage.R
+++ b/R/snapshot-manage.R
@@ -207,7 +207,13 @@ snapshot_meta <- function(files = NULL, path = "tests/testthat") {
     # Match regardless of whether user include .md or not
     files <- c(files, paste0(files, ".md"))
 
-    out <- out[out$name %in% files | out$test %in% dirs, , drop = FALSE]
+    # Also match basename to handle variant snapshots (e.g. "variant/html.md")
+    out <- out[
+      out$name %in% files |
+      basename(out$name) %in% files |
+      out$test %in% dirs,
+      , drop = FALSE
+    ]
   }
 
   out

--- a/R/snapshot-manage.R
+++ b/R/snapshot-manage.R
@@ -209,10 +209,9 @@ snapshot_meta <- function(files = NULL, path = "tests/testthat") {
 
     # Also match basename to handle variant snapshots (e.g. "variant/html.md")
     out <- out[
-      out$name %in% files |
-      basename(out$name) %in% files |
-      out$test %in% dirs,
-      , drop = FALSE
+      out$name %in% files | basename(out$name) %in% files | out$test %in% dirs,
+      ,
+      drop = FALSE
     ]
   }
 

--- a/tests/testthat/test-snapshot-manage.R
+++ b/tests/testthat/test-snapshot-manage.R
@@ -79,10 +79,37 @@ test_that("can work with variants", {
   expect_snapshot(snapshot_accept(path = path))
   expect_equal(dir(file.path(path, "_snaps", "foo")), "a.md")
 
-  # Can accept specified
+  # Can accept specified with fully qualified variant/name
   path <- local_snapshot_dir(c("foo/a.md", "foo/a.new.md"))
   expect_snapshot(snapshot_accept("foo/a", path = path))
   expect_equal(dir(file.path(path, "_snaps", "foo")), "a.md")
+
+  # Can accept by test file name alone (#2325)
+  path <- local_snapshot_dir(c("foo/a.md", "foo/a.new.md"))
+  suppressMessages(snapshot_accept("a", path = path))
+  expect_equal(dir(file.path(path, "_snaps", "foo")), "a.md")
+
+  # Can accept by test file name when multiple variants exist (#2325)
+  path <- local_snapshot_dir(c(
+    "variant1/a.md", "variant1/a.new.md",
+    "variant2/a.md", "variant2/a.new.md"
+  ))
+  suppressMessages(snapshot_accept("a", path = path))
+  expect_equal(
+    dir(file.path(path, "_snaps"), recursive = TRUE),
+    c("variant1/a.md", "variant2/a.md")
+  )
+
+  # Filtering by test name doesn't affect other test files (#2325)
+  path <- local_snapshot_dir(c(
+    "foo/a.md", "foo/a.new.md",
+    "foo/b.md", "foo/b.new.md"
+  ))
+  suppressMessages(snapshot_accept("a", path = path))
+  expect_equal(
+    dir(file.path(path, "_snaps"), recursive = TRUE),
+    c("foo/a.md", "foo/b.md", "foo/b.new.md")
+  )
 })
 
 test_that("snapshot_reject deletes .new files", {

--- a/tests/testthat/test-snapshot-manage.R
+++ b/tests/testthat/test-snapshot-manage.R
@@ -79,20 +79,22 @@ test_that("can work with variants", {
   expect_snapshot(snapshot_accept(path = path))
   expect_equal(dir(file.path(path, "_snaps", "foo")), "a.md")
 
-  # Can accept specified with fully qualified variant/name
+  # Can accept specified
   path <- local_snapshot_dir(c("foo/a.md", "foo/a.new.md"))
   expect_snapshot(snapshot_accept("foo/a", path = path))
   expect_equal(dir(file.path(path, "_snaps", "foo")), "a.md")
 
-  # Can accept by test file name alone (#2325)
+  # Can accept by test name alone (#2325)
   path <- local_snapshot_dir(c("foo/a.md", "foo/a.new.md"))
   suppressMessages(snapshot_accept("a", path = path))
   expect_equal(dir(file.path(path, "_snaps", "foo")), "a.md")
 
-  # Can accept by test file name when multiple variants exist (#2325)
+  # Can accept across multiple variants (#2325)
   path <- local_snapshot_dir(c(
-    "variant1/a.md", "variant1/a.new.md",
-    "variant2/a.md", "variant2/a.new.md"
+    "variant1/a.md",
+    "variant1/a.new.md",
+    "variant2/a.md",
+    "variant2/a.new.md"
   ))
   suppressMessages(snapshot_accept("a", path = path))
   expect_equal(
@@ -100,10 +102,12 @@ test_that("can work with variants", {
     c("variant1/a.md", "variant2/a.md")
   )
 
-  # Filtering by test name doesn't affect other test files (#2325)
+  # Only accepts matching test name (#2325)
   path <- local_snapshot_dir(c(
-    "foo/a.md", "foo/a.new.md",
-    "foo/b.md", "foo/b.new.md"
+    "foo/a.md",
+    "foo/a.new.md",
+    "foo/b.md",
+    "foo/b.new.md"
   ))
   suppressMessages(snapshot_accept("a", path = path))
   expect_equal(


### PR DESCRIPTION
Fixes #2325.

I ran into this while working on the [tufte](https://github.com/rstudio/tufte) package, where snapshot tests use variants for different pandoc/citeproc versions. After a test failure, `snapshot_review("html")` was reporting "No snapshots to update" even though a `.new.` file clearly existed.

I stepped through `snapshot_meta()` and the issue is in the filtering logic. For a variant snapshot like `_snaps/my-variant/html.md`, the `name` column ends up as `"my-variant/html.md"`, so matching against `c("html", "html.md")` fails. The documented behavior for the `files` argument says it can be "a snapshot name (e.g. `foo` or `foo.md`)", which I believe should work regardless of whether the snapshot lives in a variant subdirectory.

The fix adds a `basename(out$name)` check to the filter. I kept the existing `out$name %in% files` check because it's still needed for fully qualified paths like `snapshot_accept("my-variant/html.md")`.

I also added tests for filtering by test name with variants, including the case with multiple variant directories.
