### PR TITLE
docs: add describe() and it() to pkgdown reference index

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -21,6 +21,8 @@ reference:
 - title: Basics
   contents:
   - test_that
+  - describe
+  - it
   - expect_equal
   - expect_error
   - expect_true


### PR DESCRIPTION
Fixes #2337

The functions describe and it are exported and have a help page (describe.Rd), but are not listed on the package reference index. This adds them to the Basics section of _pkgdown.yml alongside test_that.

Changes:
- _pkgdown.yml: Added describe and it entries to the Basics section

Validation:
- Verified both functions are exported in NAMESPACE
- Verified both have existing Rd documentation
- No duplicate PRs found
- Change is minimal and follows existing pkgdown structure