### PR TITLE
Don't evaluate object twice in expect_shape

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * `run_cpp_tests()` no longer accidentally reports that a test has been skipped (#2315).
 * `expect_setequal()` uses better wording in the results (@mcol, #2310).
+* `expect_shape()` evaluates `object` only once (@michaelchirico, #2345).
 
 # testthat 3.3.2
 

--- a/R/expect-shape.R
+++ b/R/expect-shape.R
@@ -48,7 +48,7 @@ expect_shape <- function(object, ..., nrow, ncol, dim) {
   check_exclusive(nrow, ncol, dim)
   act <- quasi_label(enquo(object))
 
-  dim_object <- base::dim(object)
+  dim_object <- base::dim(act$val)
   if (is.null(dim_object)) {
     fail(sprintf("Expected %s to have dimensions.", act$lab))
   } else if (!missing(nrow)) {

--- a/tests/testthat/test-expect-shape.R
+++ b/tests/testthat/test-expect-shape.R
@@ -126,9 +126,10 @@ test_that("evaluates object only once", {
   expect_success(expect_shape({ i <- i + 1L; matrix(nrow = 2, ncol = 2) }, dim = c(2L, 2L)))
   expect_identical(i, 1L)
 
-  expect_warning(
-    expect_shape({ warning("test"); matrix(nrow = 2, ncol = 2) }, dim = c(2L, 2L)),
-    "test"
-  )
+  foo = function() { warning("test"); matrix(nrow = 2L, ncol = 2L) }
+  foo() |>
+    expect_shape(dim = c(2L, 2L)) |>
+    expect_warning("test") |>
+    expect_no_warning() # only one warning is emitted
 })
 

--- a/tests/testthat/test-expect-shape.R
+++ b/tests/testthat/test-expect-shape.R
@@ -120,3 +120,15 @@ test_that("checks inputs arguments, ", {
     expect_shape(array(1), dim = "x")
   })
 })
+
+test_that("evaluates object only once", {
+  i <- 0L
+  expect_success(expect_shape({ i <- i + 1L; matrix(nrow = 2, ncol = 2) }, dim = c(2L, 2L)))
+  expect_identical(i, 1L)
+
+  expect_warning(
+    expect_shape({ warning("test"); matrix(nrow = 2, ncol = 2) }, dim = c(2L, 2L)),
+    "test"
+  )
+})
+


### PR DESCRIPTION
Closes #2345. LLM-authored commits are annotated as such.