### PR TITLE
docs: fix two typos

### DIFF
--- a/tests/testthat/test-describe.R
+++ b/tests/testthat/test-describe.R
@@ -13,7 +13,7 @@ describe("describe", {
   })
 })
 
-test_that("can write snaphot tests", {
+test_that("can write snapshot tests", {
   local_description_set()
 
   describe("snapshot tests in describe", {

--- a/tests/testthat/test-expect-comparison.R
+++ b/tests/testthat/test-expect-comparison.R
@@ -20,7 +20,7 @@ test_that("useful output when difference is zero", {
   expect_snapshot_failure(expect_lt(x, 100))
 })
 
-test_that("useful output when differnce is large", {
+test_that("useful output when difference is large", {
   x <- 100
   expect_snapshot_failure(expect_lt(x, 0.001))
 })


### PR DESCRIPTION
docs: fix two typos

should I run:
```r
devtools::document()
```
