### PR TITLE
Pass required test_files arguments in auto_test watcher

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # testthat (development version)
 
+* `auto_test()` now reruns individual test files correctly. The watcher called
+  `test_files()` without its required `test_package` and `test_paths`
+  arguments, so every test-file-only change errored instead of rerunning.
 * `run_cpp_tests()` no longer accidentally reports that a test has been skipped (#2315).
 * `expect_setequal()` uses better wording in the results (@mcol, #2310).
 * `expect_shape()` evaluates `object` only once (@michaelchirico, #2345).

--- a/R/auto-test.R
+++ b/R/auto-test.R
@@ -53,7 +53,13 @@ auto_test <- function(
     } else if (length(tests) > 0) {
       # If test changes, rerun just that test
       cat("Rerunning tests: ", paste0(basename(tests), collapse = ", "), "\n")
-      test_files(tests, env = env, reporter = reporter$clone(deep = TRUE))
+      test_files(
+        test_dir = test_path,
+        test_package = NULL,
+        test_paths = tests,
+        env = env,
+        reporter = reporter$clone(deep = TRUE)
+      )
     }
 
     TRUE


### PR DESCRIPTION
The watcher inside `auto_test()` in R/auto-test.R reran a changed test file with:

```r
test_files(tests, env = env, reporter = reporter$clone(deep = TRUE))
```

`test_files()` requires `test_dir`, `test_package`, and `test_paths`, and none has a default. `tests` landed in `test_dir`, and `test_package` and `test_paths` were missing, so every test-file-only change errored with an "argument is missing, with no default" error instead of rerunning the file. Editing a test file under `auto_test()` never worked.

The call now supplies the required arguments, mirroring the sibling watcher in `auto_test_package()`:

```r
test_files(
  test_dir = test_path,
  test_package = NULL,
  test_paths = tests,
  env = env,
  reporter = reporter$clone(deep = TRUE)
)
```

`test_package = NULL` is safe here because `local_test_directory()` already defaults `package = NULL`. 

Found during my most recent [ry](https://github.com/sims1253/ry) audit.
